### PR TITLE
Add base26+32+36+49+52+58+62 encodings, make base64 URL-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 	},
 	"devDependencies": {
 		"should": "~4.0.4",
-		"mocha": "~1.21.3"
+		"mocha": "~1.21.3",
+		"bignum": "~0.9.0"
 	},
 	"scripts": {
 		"test": "mocha -R spec"


### PR DESCRIPTION
What the title says, also base64 used unsafe characters `/+` before which is not a good idea. :)

`hex` is roughly 50% longer than `base62`
