### PR TITLE
feat: add `option.sourceMap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ use: "file-loader?name=[name].[ext]&publicPath=assets/foo/&outputPath=app/images
   * and `length` the length in chars
 * `[N]` the N-th match obtained from matching the current file name against the query param `regExp`
 
+#### Source Maps
+
+If you are working with a text-based file with a source map, you can have the source map emitted along with the file using the `sourceMap` parameter.
+
 #### Examples
 
 ``` javascript
@@ -84,6 +88,10 @@ require("file-loader?name=html-[hash:6].html!./page.html");
 
 require("file-loader?name=[hash]!./flash.txt");
 // => c31e9820c001c9c4a86bce33ce43b679
+
+require("file-loader?name=styles.css&sourceMap!postcss!./styles.css")
+// => styles.css
+// => styles.css.map
 
 require("file-loader?name=[sha512:hash:base64:7].[ext]!./image.png");
 // => gdyb21L.png

--- a/index.js
+++ b/index.js
@@ -4,8 +4,9 @@
 */
 var path = require("path");
 var loaderUtils = require("loader-utils");
+var path = require("path");
 
-module.exports = function(content) {
+module.exports = function(content, map) {
 	this.cacheable && this.cacheable();
 	if(!this.emitFile) throw new Error("emitFile is required from module system");
 
@@ -71,6 +72,18 @@ module.exports = function(content) {
 	}
 
 	if (query.emitFile === undefined || query.emitFile) {
+		if (this.sourceMap && config.sourceMap && map) {
+			var basename = path.basename(url)
+			content = Buffer.concat([
+				content,
+				new Buffer(
+					/\.css($|\?)/i.test(basename)
+					? "\n/*# sourceMappingURL=" + basename + ".map*/"
+					: "\n//# sourceMappingURL=" + basename + ".map"
+				)
+			]);
+			this.emitFile(outputPath + ".map", JSON.stringify(map));
+		}
 		this.emitFile(outputPath, content);
 	}
 

--- a/test/optional-sourcemap.test.js
+++ b/test/optional-sourcemap.test.js
@@ -1,0 +1,67 @@
+var should = require("should");
+var fileLoader = require("../");
+
+function run(resourcePath, query, contextSourceMap, map) {
+	var content = new Buffer("1234");
+	var result = [];
+	var context = {
+		resourcePath: resourcePath,
+		query: "?name=[name].[ext]&" + query,
+		options: {
+			context: "/this/is/the/context"
+		},
+		emitFile: function(url, content) {
+			result.push([ url, content ]);
+		},
+		sourceMap: contextSourceMap
+	};
+	fileLoader.call(context, content, map);
+	return result;
+}
+
+describe("optional-sourcemap", function() {
+	it("should emit a sourcemap when requested", function() {
+		var files = run("whatever.txt", "sourceMap", true, {});
+		files.length.should.equal(2);
+		files[0].should.eql([ "file.txt.map", "{}" ]);
+		files[1][0].should.equal("file.txt");
+		files[1][1].toString().should.equal(
+			"1234\n//# sourceMappingURL=file.txt.map"
+		);
+	});
+
+	it("should use css comment when file has css extension", function() {
+		var files = run("whatever.css", "sourceMap", true, { v: 1 });
+		files.length.should.equal(2);
+		files[0].should.eql([ "file.css.map", '{"v":1}' ]);
+		files[1][0].should.equal("file.css");
+		files[1][1].toString().should.equal(
+			"1234\n/*# sourceMappingURL=file.css.map*/"
+		);
+	});
+
+	it("should not emit a sourcemap without query parameter", function() {
+		var files = run("whatever.txt", "", true, {});
+		files.length.should.equal(1);
+	});
+
+	it("should not emit a sourcemap without loader context with sourceMap", function() {
+		var files = run("whatever.txt", "sourceMap", false, {});
+		files.length.should.equal(1);
+	});
+
+	it("should not emit a sourcemap without recieving a sourcemap", function() {
+		var files = run("whatever.txt", "sourceMap", true, null);
+		files.length.should.equal(1);
+	});
+
+	it("should not emit a sourcemap when emitFile=false", function() {
+		var files = run("whatever.txt", "sourceMap&emitFile=false", true, {});
+		files.length.should.equal(0);
+	});
+
+	it("should emit only the file by default", function() {
+		var files = run("whatever.txt", "", false, null);
+		files.length.should.equal(1);
+	});
+});


### PR DESCRIPTION
If there is a source map, and source maps are enabled, and you explicitly ask for sourceMap, emit the source map and append the mapping url comment.

Because file-loader is usually used for binary files or other files that would be corrupted by appending the comment, require the query flag.

Use case:

```
{ test:/\.css$/, loaders: [ 'file?sourceMap', 'cssnext' ] },
{ test:/\.svg$/, loaders: [ 'file?sourceMap', 'svgo' ] } // assuming source maps were supported by some svg transformer
```
