### PR TITLE
Export an ES Module instead of CommonJS module

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,6 @@ module.exports = function(content) {
 		this.emitFile(url, content);
 	}
 
-	return "module.exports = " + publicPath + ";";
+	return "export default " + publicPath + ";";
 }
 module.exports.raw = true;


### PR DESCRIPTION
Since webpack v2, it's better to use ES modules. Note that this is incompatible with webpack v1, so it should be released as a major version.

Fixes #96.