### PR TITLE
chore(release): add standard version & documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "devDependencies": {
     "should": "~4.0.4",
+    "standard-version": "^4.0.0",
     "mocha": "~1.21.3"
   },
   "scripts": {
-    "test": "mocha -R spec"
+    "test": "mocha -R spec",
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As discussed in webpack/webpack#4104

- Adds standard-version
- Release docs now in https://webpack.js.org/development/release-process/
- Adds empty changelog ( will require some `reword` work to get the full history )
