### PR TITLE
fix: allow the usage of an empty string as publicPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function(content) {
 		 : config.outputPath + url
 	}
 
-	if (config.publicPath) {
+	if (config.publicPath !== false) {
 		// support functions as publicPath to generate them dynamically
 		publicPath = JSON.stringify(
 				typeof config.publicPath === "function"


### PR DESCRIPTION
This pull request enforces a more strict check of `publicPath` to prevent the interpretation of empty string as false value. This allows to disable the prefixing of `publicPath` with `__webpack_public_path__` without the need to provide a function that simply returns the `url` as given.

Current work around would be to use

```js
query: {
  publicPath: (url) => url
}
```