### PR TITLE
Use dot-separated path such as loader.fileLoader for additional options

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,29 @@
 */
 var loaderUtils = require("loader-utils");
 
+function getOptions (obj, key) {
+	if (!key) {
+		return {}
+	}
+	var keyPaths = key.split('.');
+	var Options = obj;
+	for (var path of keyPaths) {
+		if (Options) {
+			Options = Options[path];
+		} else {
+			return {};
+		}
+	}
+	return Options || {};
+}
+
 module.exports = function(content) {
 	this.cacheable && this.cacheable();
-	if(!this.emitFile) throw new Error("emitFile is required from module system");
+	if (!this.emitFile) throw new Error("emitFile is required from module system");
 
 	var query = loaderUtils.parseQuery(this.query);
 	var configKey = query.config || "fileLoader";
-	var options = this.options[configKey] || {};
+	var options = getOptions(this.options, configKey);
 
 	var config = {
 		publicPath: false,


### PR DESCRIPTION
Use dot-separated path such as loader.fileLoader for additional options for webpack 2

**What kind of change does this PR introduce?**
feature

**Did you add tests for your changes?**
no

**If relevant, did you update the README?**
no

**Summary**

As mentioned in Issue #126, when used in webpack 2, with default settings, no additional options is allowed to add to the root of the webpack config, that is, no fileLoader option is allowed for additional publicpath callback function.

There is a loader option for webpack 2 allows any object. We can set query.config to `loader`.
A better way to do so is set query.config to `loader.fileLoader` that will avoid conflict with other loaders.

The new getOptions function will be used here to get the webpack options with dot-separated path.

**Does this PR introduce a breaking change?**
no

**Other information**
Not much information about `loader` option in webpack config is published, the purpose and usage of this property may change.
