### PR TITLE
fix(getOptions): deprecation warn in loaderUtils

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(content) {
 	this.cacheable && this.cacheable();
 	if(!this.emitFile) throw new Error("emitFile is required from module system");
 
-	var query = loaderUtils.parseQuery(this.query);
+	var query = loaderUtils.getOptions(this) || {};
 	var configKey = query.config || "fileLoader";
 	var options = this.options[configKey] || {};
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "index.js"
   ],
   "dependencies": {
-    "loader-utils": "~0.2.5"
+    "loader-utils": "^1.0.2"
   },
   "devDependencies": {
     "should": "~4.0.4",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bugfix

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- loader-utils change is throwing a DeprecationWarning in pretty much any loader on the planet.

`loaderUtils.parseQuery` is now `loderUtils.getOptions`

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**

Closes #128