### PR TITLE
fix: outputPath function overriden by useRelativePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,6 @@ module.exports = function(content) {
 			? config.outputPath(url)
 			: config.outputPath + url
 		);
-	}
 		url = outputPath;
 	} else {
 		outputPath = url;

--- a/index.js
+++ b/index.js
@@ -36,14 +36,6 @@ module.exports = function(content) {
 	});
 
 	var outputPath = "";
-	if (config.outputPath) {
-		// support functions as outputPath to generate them dynamically
-		outputPath = (
-			typeof config.outputPath === "function"
-			? config.outputPath(url)
-			: config.outputPath
-		);
-	}
 
 	var filePath = this.resourcePath;
 	if (config.useRelativePath) {
@@ -56,8 +48,14 @@ module.exports = function(content) {
 			outputPath = relativePath + url;
 		}
 		url = relativePath + url;
-	} else if (outputPath) {
-		outputPath = outputPath + url;
+	} else if (config.outputPath) {
+		// support functions as outputPath to generate them dynamically
+		outputPath = (
+			typeof config.outputPath === "function"
+			? config.outputPath(url)
+			: config.outputPath + url
+		);
+	}
 		url = outputPath;
 	} else {
 		outputPath = url;

--- a/test/correct-filename.test.js
+++ b/test/correct-filename.test.js
@@ -24,6 +24,29 @@ function run(resourcePath, query, content) {
 		result: result
 	}
 }
+function run_with_options(resourcePath,options, content) {
+	content = content || new Buffer("1234");
+	var file = null;
+
+	var context = {
+		resourcePath: resourcePath,
+		options: {
+			"fileLoader": options,
+			context: "/this/is/the/context"
+		},
+    	emitFile: function(url, content2) {
+			content2.should.be.eql(content);
+			file = url;
+		}
+	};
+
+	var result = fileLoader.call(context, content)
+
+	return {
+		file: file,
+		result: result
+	}
+}
 
 function test(excepted, resourcePath, query, content) {
 	run(resourcePath, query, content).file.should.be.eql(excepted);
@@ -86,4 +109,31 @@ describe("useRelativePath option", function() {
 			'module.exports = __webpack_public_path__ + \"this/81dc9bdb52d04dc20036dbd8313ed055.txt\";'
 		);
 	});
+});
+describe("outputPath function", function() {
+	it("should be supported", function() {
+      outputFunc = function(value) {
+        return("/path/set/by/func");
+
+      };
+      var options = {};
+      options.outputPath = outputFunc;
+      run_with_options("/this/is/the/context/file.txt", options).result.should.be.eql(
+        'module.exports = __webpack_public_path__ + \"/path/set/by/func\";'
+      );
+
+	});
+	it("should be ignored if you set useRelativePath", function() {
+	      outputFunc = function(value) {
+	        return("/path/set/by/func");
+
+	      };
+	      var options = {};
+	      options.outputPath = outputFunc;
+	      options.useRelativePath = true;
+	      run_with_options("/this/is/the/context/file.txt", options).result.should.be.eql(
+	        'module.exports = __webpack_public_path__ + \"./81dc9bdb52d04dc20036dbd8313ed055.txt\";'
+	      );
+
+		});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix -  The new useRelativePath option code - did not handle the case where you used a function for the outputPath generation. 
**Did you add tests for your changes?**
Yes - I added in a test to make sure that if you use a function for outputPath it is called. If you use the useRelativePath it is ignored.
**If relevant, did you update the README?**
You don't currently document using outputPath as a function so I wasn't sure I should.
**Summary**
New code broke old behavior. If you use a function to set the outputPath it was expected that the function would be the decider on where the output of the file is.  Recent code took that away:(

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Motivation: Recent code broke old behavior. I updated to the current version and my app stopped generating correctly.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No - it restores functionality.

**Other information**
There weren't any tests for outputPath as a function. I've added one so that in the future the feature will be protected.