### PR TITLE
fix: allow to override publicPath with an empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function(content) {
 	}
 
 	var publicPath = "__webpack_public_path__ + " + JSON.stringify(url);
-	if (config.publicPath || config.publicPath === "") {
+	if (config.publicPath !== false) {
 		// support functions as publicPath to generate them dynamically
 		publicPath = JSON.stringify(
 			typeof config.publicPath === "function"

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function(content) {
 	}
 
 	var publicPath = "__webpack_public_path__ + " + JSON.stringify(url);
-	if (config.publicPath || config.publicPath === '') {
+	if (config.publicPath || config.publicPath === "") {
 		// support functions as publicPath to generate them dynamically
 		publicPath = JSON.stringify(
 			typeof config.publicPath === "function"

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function(content) {
 	}
 
 	var publicPath = "__webpack_public_path__ + " + JSON.stringify(url);
-	if (config.publicPath) {
+	if (config.publicPath || config.publicPath === '') {
 		// support functions as publicPath to generate them dynamically
 		publicPath = JSON.stringify(
 			typeof config.publicPath === "function"

--- a/test/correct-filename.test.js
+++ b/test/correct-filename.test.js
@@ -92,6 +92,18 @@ describe("publicPath option", function() {
 			'module.exports = "http://cdn/81dc9bdb52d04dc20036dbd8313ed055.txt";'
 		);
 	});
+
+	it("should override public path when given empty string", function() {
+		run("file.txt", "publicPath=").result.should.be.eql(
+			'module.exports = "81dc9bdb52d04dc20036dbd8313ed055.txt";'
+		);
+	});
+
+	it("should use webpack public path when not set", function() {
+		run("file.txt").result.should.be.eql(
+			'module.exports = __webpack_public_path__ + "81dc9bdb52d04dc20036dbd8313ed055.txt";'
+		);
+	});
 });
 
 describe("useRelativePath option", function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bugfix.
**Did you add tests for your changes?**
Yes.

**Summary**
When checking if the publicPath option was set, it would only do a falsy check which would return false with an empty string. Modified it to also set the public path if an empty string is given.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.
**Other information**
