### PR TITLE
feat(index): add context to `outputPath` && `publicPath`

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ module.exports = function(content) {
 	var outputPath = "";
 
 	var filePath = this.resourcePath;
+	var issuerContext = this._module && this._module.issuer && this._module.issuer.context || context;
 	if (config.useRelativePath) {
-		var issuerContext = this._module && this._module.issuer && this._module.issuer.context || context;
 		var relativeUrl = issuerContext && path.relative(issuerContext, filePath).split(path.sep).join("/");
 		var relativePath = relativeUrl && path.dirname(relativeUrl) + "/";
 		if (~relativePath.indexOf("../")) {
@@ -48,11 +48,12 @@ module.exports = function(content) {
 			outputPath = relativePath + url;
 		}
 		url = relativePath + url;
-	} else if (config.outputPath) {
+	}
+	if (config.outputPath) {
 		// support functions as outputPath to generate them dynamically
 		outputPath = (
 			typeof config.outputPath === "function"
-			? config.outputPath(url)
+			? config.outputPath(url, issuerContext)
 			: config.outputPath + url
 		);
 		url = outputPath;
@@ -65,7 +66,7 @@ module.exports = function(content) {
 		// support functions as publicPath to generate them dynamically
 		publicPath = JSON.stringify(
 			typeof config.publicPath === "function"
-			? config.publicPath(url)
+			? config.publicPath(url, issuerContext)
 			: config.publicPath + url
 		);
 	}

--- a/index.js
+++ b/index.js
@@ -38,22 +38,21 @@ module.exports = function(content) {
 	var outputPath = "";
 
 	var filePath = this.resourcePath;
-	var issuerContext = this._module && this._module.issuer && this._module.issuer.context || context;
+	context = this.context || context;
+
 	if (config.useRelativePath) {
-		var relativeUrl = issuerContext && path.relative(issuerContext, filePath).split(path.sep).join("/");
+		var relativeUrl = context && path.relative(context, filePath).split(path.sep).join("/");
 		var relativePath = relativeUrl && path.dirname(relativeUrl) + "/";
-		if (~relativePath.indexOf("../")) {
-			outputPath = path.posix.join(outputPath, relativePath, url);
-		} else {
-			outputPath = relativePath + url;
-		}
+
+		outputPath = path.posix.join(context, relativePath, url);
+
 		url = relativePath + url;
-	}
-	if (config.outputPath) {
+	} else if (config.outputPath) {
 		// support functions as outputPath to generate them dynamically
 		outputPath = (
 			typeof config.outputPath === "function"
-			? config.outputPath(url, issuerContext)
+			// `this` for webpack loader API
+			? config.outputPath(url, this)
 			: config.outputPath + url
 		);
 		url = outputPath;
@@ -66,7 +65,8 @@ module.exports = function(content) {
 		// support functions as publicPath to generate them dynamically
 		publicPath = JSON.stringify(
 			typeof config.publicPath === "function"
-			? config.publicPath(url, issuerContext)
+			// `this` for webpack loader API
+			? config.publicPath(url, this)
 			: config.publicPath + url
 		);
 	}


### PR DESCRIPTION
I propose to add issuerContext to outputPath and publicPath to allow users change the resolved paths dynamically (eg. implementing relative path by myself).
BTW,  the outputPath should be able to be changed by the users after using "useRelativePath" because it will emit files to wrong paths (eg. files will be placed to parent folder of output path when it starts with "..").
