### PR TITLE
fix: init `publicPath` to undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function(content) {
 	var configKey = query.config || "fileLoader";
 	var options = this.options[configKey] || {};
 	var config = {
-		publicPath: false,
+		publicPath: undefined,
 		useRelativePath: false,
 		name: "[hash].[ext]"
 	};
@@ -61,7 +61,7 @@ module.exports = function(content) {
 	}
 
 	var publicPath = "__webpack_public_path__ + " + JSON.stringify(url);
-	if (config.publicPath !== false) {
+	if (config.publicPath !== undefined) {
 		// support functions as publicPath to generate them dynamically
 		publicPath = JSON.stringify(
 			typeof config.publicPath === "function"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**

**If relevant, did you update the README?**

**Summary**
Initializing `publicPath` to false was preventing the new option from being used with `webpack-config-validator
`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

See comment in #145

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**

Fixes #158 
