### PR TITLE
feat: add context to `options.outputPath` && `options.publicPath`

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,12 +50,9 @@ module.exports = function(content) {
 		url = relativePath + url;
 	} else if (config.outputPath) {
 		// support functions as outputPath to generate them dynamically
-                var userRequest = this._module && this._module.userRequest
-                var rawRequest = this._module && this._module.rawRequest
-                var context = this._module && this._module.issuer && this._module.issuer.context || context;
 		outputPath = (
 			typeof config.outputPath === "function"
-			? config.outputPath(url, { userRequest, rawRequest, context })
+			? config.outputPath(url, this._module || {})
 			: config.outputPath + url
 		);
 		url = outputPath;
@@ -66,12 +63,9 @@ module.exports = function(content) {
 	var publicPath = "__webpack_public_path__ + " + JSON.stringify(url);
 	if (config.publicPath !== undefined) {
 		// support functions as publicPath to generate them dynamically
-                var userRequest = this._module && this._module.userRequest
-                var rawRequest = this._module && this._module.rawRequest
-                var context = this._module && this._module.issuer && this._module.issuer.context || context;
 		publicPath = JSON.stringify(
 			typeof config.publicPath === "function"
-			? config.publicPath(url, { userRequest, rawRequest, context })
+			? config.publicPath(url, this._module || {})
 			: config.publicPath + url
 		);
 	}

--- a/index.js
+++ b/index.js
@@ -50,9 +50,12 @@ module.exports = function(content) {
 		url = relativePath + url;
 	} else if (config.outputPath) {
 		// support functions as outputPath to generate them dynamically
+                var userRequest = this._module && this._module.userRequest
+                var rawRequest = this._module && this._module.rawRequest
+                var context = this._module && this._module.issuer && this._module.issuer.context || context;
 		outputPath = (
 			typeof config.outputPath === "function"
-			? config.outputPath(url)
+			? config.outputPath(url, { userRequest, rawRequest, context })
 			: config.outputPath + url
 		);
 		url = outputPath;
@@ -63,9 +66,12 @@ module.exports = function(content) {
 	var publicPath = "__webpack_public_path__ + " + JSON.stringify(url);
 	if (config.publicPath !== undefined) {
 		// support functions as publicPath to generate them dynamically
+                var userRequest = this._module && this._module.userRequest
+                var rawRequest = this._module && this._module.rawRequest
+                var context = this._module && this._module.issuer && this._module.issuer.context || context;
 		publicPath = JSON.stringify(
 			typeof config.publicPath === "function"
-			? config.publicPath(url)
+			? config.publicPath(url, { userRequest, rawRequest, context })
 			: config.publicPath + url
 		);
 	}

--- a/test/correct-filename.test.js
+++ b/test/correct-filename.test.js
@@ -48,6 +48,32 @@ function run_with_options(resourcePath,options, content) {
 	}
 }
 
+function run_with_path_callbacks(resourcePath, query, content) {
+	content = content || new Buffer("1234");
+	var result = { publicPath: false, outputPath: false };
+	var context = {
+		resourcePath: resourcePath,
+		query: "?" + query,
+		options: {
+			context: "/this/is/the/context",
+                        fileLoader: {
+                                publicPath: function(url, module) {
+                                  if (!!module)
+                                    result.publicPath = true
+                                },
+                                outputPath: function(url, module) {
+                                  if (!!module)
+                                    result.outputPath = true
+                                }
+                        },
+		},
+		emitFile: function(url, content2) {
+		}
+	};
+	fileLoader.call(context, content);
+	return result;
+}
+
 function test(excepted, resourcePath, query, content) {
 	run(resourcePath, query, content).file.should.be.eql(excepted);
 }
@@ -104,6 +130,14 @@ describe("publicPath option", function() {
 			'module.exports = __webpack_public_path__ + "81dc9bdb52d04dc20036dbd8313ed055.txt";'
 		);
 	});
+
+        it("should call publicPath callback with module", function() {
+                run_with_path_callbacks("whatever.txt", "").should.property("publicPath", true);
+        });
+
+        it("should call outputPath callback with module", function() {
+                run_with_path_callbacks("whatever.txt", "").should.property("outputPath", true);
+        });
 });
 
 describe("useRelativePath option", function() {


### PR DESCRIPTION
The context includes three fields userRequest, rawRequest and issuer context.

**What kind of change does this PR introduce?**
Adds functionality to outputPath and publicPath options (when set to functions)

**Did you add tests for your changes?**
Yes.

**If relevant, did you update the README?**
No, not yet, waiting for comments.

**Summary**
I am working on an react app in which I need to have relative path for files.  The static assets are served from `./static` folder.  When the app is requesting images there are two cases:
* they are requested from javascript bundle they need to have publicPath set to "./static/"
* if they are requested from "style.css" which by itself is inside "./static" folder they need to be relative to "./" rather than "./static"

**Does this PR introduce a breaking change?**
No.

**Other information**
