### PR TITLE
fix: remove `=` from default export (`SyntaxError`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export default function fileLoader(content) {
     this.emitFile(outputPath, content);
   }
 
-  return `export default = ${publicPath};`;
+  return `export default ${publicPath};`;
 }
 
 export const raw = true;

--- a/test/correct-filename.test.js
+++ b/test/correct-filename.test.js
@@ -87,17 +87,17 @@ describe('correct-filename', () => {
 describe('publicPath option', () => {
   it('should be supported', () => {
     expect(run('/file.txt', 'publicPath=http://cdn/').result).toEqual(
-      'export default = "http://cdn/81dc9bdb52d04dc20036dbd8313ed055.txt";',
+      'export default "http://cdn/81dc9bdb52d04dc20036dbd8313ed055.txt";',
     );
   });
   it('should override public path when given empty string', () => {
     expect(run('/file.txt', 'publicPath=').result).toEqual(
-      'export default = "81dc9bdb52d04dc20036dbd8313ed055.txt";',
+      'export default "81dc9bdb52d04dc20036dbd8313ed055.txt";',
     );
   });
   it('should use webpack public path when not set', () => {
     expect(run('/file.txt').result).toEqual(
-      'export default = __webpack_public_path__ + "81dc9bdb52d04dc20036dbd8313ed055.txt";',
+      'export default __webpack_public_path__ + "81dc9bdb52d04dc20036dbd8313ed055.txt";',
     );
   });
 });
@@ -105,16 +105,16 @@ describe('publicPath option', () => {
 describe('useRelativePath option', () => {
   it('should be supported', () => {
     expect(run('/this/is/the/context/file.txt', 'useRelativePath=true').result).toEqual(
-      'export default = __webpack_public_path__ + \"./81dc9bdb52d04dc20036dbd8313ed055.txt\";',
+      'export default __webpack_public_path__ + \"./81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
     expect(run('/this/is/file.txt', 'useRelativePath=true').result).toEqual(
-      'export default = __webpack_public_path__ + \"../../81dc9bdb52d04dc20036dbd8313ed055.txt\";',
+      'export default __webpack_public_path__ + \"../../81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
     expect(run('/this/file.txt', 'context=/this/is/the/&useRelativePath=true').result).toEqual(
-      'export default = __webpack_public_path__ + \"../../81dc9bdb52d04dc20036dbd8313ed055.txt\";',
+      'export default __webpack_public_path__ + \"../../81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
     expect(run('/this/file.txt', 'context=/&useRelativePath=true').result).toEqual(
-      'export default = __webpack_public_path__ + \"this/81dc9bdb52d04dc20036dbd8313ed055.txt\";',
+      'export default __webpack_public_path__ + \"this/81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
   });
 });
@@ -125,7 +125,7 @@ describe('outputPath function', () => {
     const options = {};
     options.outputPath = outputFunc;
     expect(runWithOptions('/this/is/the/context/file.txt', options).result).toEqual(
-      'export default = __webpack_public_path__ + \"/path/set/by/func\";',
+      'export default __webpack_public_path__ + \"/path/set/by/func\";',
     );
   });
   it('should be ignored if you set useRelativePath', () => {
@@ -134,7 +134,7 @@ describe('outputPath function', () => {
     options.outputPath = outputFunc;
     options.useRelativePath = true;
     expect(runWithOptions('/this/is/the/context/file.txt', options).result).toEqual(
-      'export default = __webpack_public_path__ + \"./81dc9bdb52d04dc20036dbd8313ed055.txt\";',
+      'export default __webpack_public_path__ + \"./81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
   });
 });


### PR DESCRIPTION
The refactoring to ES modules (#167) accidentally left an `=` in the default export, which is a syntax error.