### PR TITLE
fix(cjs): export `raw` value

### DIFF
--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,1 +1,4 @@
-module.exports = require('./index').default;
+const loader = require('./index');
+
+module.exports = loader.default;
+module.exports.raw = loader.raw;

--- a/test/cjs.test.js
+++ b/test/cjs.test.js
@@ -1,0 +1,12 @@
+import fileLoader from '../src';
+import cjsFileLoader from '../src/cjs';
+
+describe('cjs', () => {
+  it('should export loader', () => {
+    expect(cjsFileLoader).toEqual(fileLoader);
+  });
+
+  it('should export `raw` flag', () => {
+    expect(cjsFileLoader.raw).toEqual(true);
+  });
+});


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

We use `"main": "dist/cjs.js"` in `package.json`, but `default`(https://github.com/webpack-contrib/file-loader/blob/master/src/cjs.js#L1) doesn't contain `raw` value so `file-loader` doesn't work correctly.