### PR TITLE
feat: add `options` validation (`schema-utils`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "file-loader",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abab": {
       "version": "1.0.3",
@@ -20,6 +21,9 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
+      "requires": {
+        "acorn": "4.0.13"
+      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -34,6 +38,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -47,7 +54,10 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -59,7 +69,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -71,7 +86,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "2.0.0"
+      }
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -95,7 +113,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "app-root-path": {
       "version": "2.0.1",
@@ -107,19 +129,28 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "1.0.0"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.0.3"
+      }
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -149,7 +180,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -185,7 +219,10 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
       "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -216,121 +253,255 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
       "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "6.25.0",
+        "babel-polyfill": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "chokidar": "1.7.0",
+        "commander": "2.9.0",
+        "convert-source-map": "1.5.0",
+        "fs-readdir-recursive": "1.0.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.6",
+        "v8flags": "2.1.1"
+      }
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "babel-core": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
       "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-generator": "6.25.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.8",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.7",
+        "slash": "1.0.0",
+        "source-map": "0.5.6"
+      }
     },
     "babel-generator": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
+      }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
       "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
       "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
     },
     "babel-jest": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
       "integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "6.25.0",
+        "babel-plugin-istanbul": "4.1.4",
+        "babel-preset-jest": "20.0.3"
+      }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-istanbul": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
       "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.7.2",
+        "test-exclude": "4.1.1"
+      }
     },
     "babel-plugin-jest-hoist": {
       "version": "20.0.3",
@@ -366,211 +537,411 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "6.24.1",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
       "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "regexpu-core": "2.0.0"
+      }
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
       "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
       "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.9.11"
+      }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-polyfill": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
     },
     "babel-preset-env": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.2.tgz",
       "integrity": "sha1-zUrpCm6Utwn5c3SzPl+LmDVWre8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.24.1",
+        "browserslist": "2.1.4",
+        "invariant": "2.2.2",
+        "semver": "5.3.0"
+      }
     },
     "babel-preset-jest": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
       "integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "20.0.3"
+      }
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "6.25.0",
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.15"
+      }
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
     },
     "babel-template": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3",
+        "lodash": "4.17.4"
+      }
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.17.3",
@@ -589,7 +960,10 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "big.js": {
       "version": "3.1.3",
@@ -607,13 +981,25 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "boxen": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
       "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
       "dev": true,
+      "requires": {
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.0.0",
+        "term-size": "0.1.1",
+        "widest-line": "1.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
@@ -627,19 +1013,31 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "browser-resolve": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
       "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
@@ -653,13 +1051,20 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.1.4.tgz",
       "integrity": "sha1-zFJq9KExK30uBWU+VtDIq3DA4FM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000680",
+        "electron-to-chromium": "1.3.14"
+      }
     },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "node-int64": "0.4.0"
+      }
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -672,6 +1077,15 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-3.0.4.tgz",
       "integrity": "sha1-bSTO7Dcu/lybeYgIvH9JtHJCpO8=",
       "dev": true,
+      "requires": {
+        "camelcase-keys": "3.0.0",
+        "chalk": "1.1.3",
+        "indent-string": "3.1.0",
+        "minimist": "1.2.0",
+        "read-pkg-up": "1.0.1",
+        "suffix": "0.1.0",
+        "text-table": "0.2.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -683,7 +1097,11 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-3.0.0.tgz",
           "integrity": "sha1-/AxsNgNj9zd+N5O5oWvM8QcMHKQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "map-obj": "1.0.1"
+          }
         },
         "indent-string": {
           "version": "3.1.0",
@@ -703,7 +1121,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -721,7 +1142,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
     },
     "caniuse-lite": {
       "version": "1.0.30000680",
@@ -746,20 +1171,42 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.1",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "ci-info": {
       "version": "1.0.0",
@@ -783,7 +1230,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-spinners": {
       "version": "0.1.2",
@@ -796,18 +1246,30 @@
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -823,6 +1285,11 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -836,8 +1303,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -849,7 +1315,10 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.2"
+      }
     },
     "color-name": {
       "version": "1.1.2",
@@ -861,25 +1330,38 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "compare-func": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
+      "requires": {
+        "array-ify": "1.0.0",
+        "dot-prop": "3.0.0"
+      },
       "dependencies": {
         "dot-prop": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
         }
       }
     },
@@ -893,13 +1375,26 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.11",
+        "typedarray": "0.0.6"
+      }
     },
     "configstore": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
       "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.1.1",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -917,91 +1412,182 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.3.tgz",
       "integrity": "sha1-JigweKw4wJTfKvFgSwpGu8AWXE0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "1.3.3",
+        "conventional-changelog-atom": "0.1.0",
+        "conventional-changelog-codemirror": "0.1.0",
+        "conventional-changelog-core": "1.8.0",
+        "conventional-changelog-ember": "0.2.5",
+        "conventional-changelog-eslint": "0.1.0",
+        "conventional-changelog-express": "0.1.0",
+        "conventional-changelog-jquery": "0.1.0",
+        "conventional-changelog-jscs": "0.1.0",
+        "conventional-changelog-jshint": "0.1.0"
+      }
     },
     "conventional-changelog-angular": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.3.tgz",
       "integrity": "sha1-586AeoXdR1DhtBf3ZgRUl1EeByY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "compare-func": "1.3.2",
+        "github-url-from-git": "1.5.0",
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-atom": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
       "integrity": "sha1-Z6R8ZqQrL4kJ7xWHyZia4d5zC5I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-codemirror": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
       "integrity": "sha1-dXelkdv5tTjnoVCn7mL2WihyszQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-core": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.8.0.tgz",
       "integrity": "sha1-l3hItBbK8V+wnyCxKmLUDvFFuVc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "conventional-changelog-writer": "1.4.1",
+        "conventional-commits-parser": "1.3.0",
+        "dateformat": "1.0.12",
+        "get-pkg-repo": "1.3.0",
+        "git-raw-commits": "1.2.0",
+        "git-remote-origin-url": "2.0.0",
+        "git-semver-tags": "1.2.0",
+        "lodash": "4.17.4",
+        "normalize-package-data": "2.3.8",
+        "q": "1.5.0",
+        "read-pkg": "1.1.0",
+        "read-pkg-up": "1.0.1",
+        "through2": "2.0.3"
+      }
     },
     "conventional-changelog-ember": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.5.tgz",
       "integrity": "sha1-ziHVz4PNXr4F0j/fIy2IRPS1ak8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-eslint": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
       "integrity": "sha1-pSQR6ZngUBzlALhWsKZD0DMJB+I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-express": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
       "integrity": "sha1-VcbIQcgRliA2wDe9vZZKVK4xD84=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-jquery": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-jscs": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-jshint": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz",
       "integrity": "sha1-AMq46aMxdIer2UxNhGcTQpGNKgc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "compare-func": "1.3.2",
+        "q": "1.5.0"
+      }
     },
     "conventional-changelog-writer": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
       "integrity": "sha1-P0y00APrtWmJ0w00WJO1KkNjnI4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "compare-func": "1.3.2",
+        "conventional-commits-filter": "1.0.0",
+        "dateformat": "1.0.12",
+        "handlebars": "4.0.10",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.4",
+        "meow": "3.7.0",
+        "semver": "5.3.0",
+        "split": "1.0.0",
+        "through2": "2.0.3"
+      }
     },
     "conventional-commits-filter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
       "integrity": "sha1-b8KmWTcrw/IznPn//34bA0S5MDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.0"
+      }
     },
     "conventional-commits-parser": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-text-path": "1.0.1",
+        "JSONStream": "1.3.1",
+        "lodash": "4.17.4",
+        "meow": "3.7.0",
+        "split2": "2.1.1",
+        "through2": "2.0.3",
+        "trim-off-newlines": "1.0.1"
+      }
     },
     "conventional-recommended-bump": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-0.3.0.tgz",
       "integrity": "sha1-6Dnej1fLtDRFyLSWdAHeBkTEJdg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "conventional-commits-filter": "1.0.0",
+        "conventional-commits-parser": "1.3.0",
+        "git-latest-semver-tag": "1.0.2",
+        "git-raw-commits": "1.2.0",
+        "meow": "3.7.0",
+        "object-assign": "4.1.1"
+      }
     },
     "convert-source-map": {
       "version": "1.5.0",
@@ -1026,6 +1612,16 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
       "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "js-yaml": "3.8.4",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "require-from-string": "1.2.1"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -1039,37 +1635,63 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-4.2.0.tgz",
       "integrity": "sha1-cVNhZjtx7eC23dvDyA4roC5yXsM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "nested-error-stacks": "2.0.0",
+        "pify": "2.3.0",
+        "safe-buffer": "5.0.1"
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
     },
     "cross-env": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.0.1.tgz",
       "integrity": "sha1-/05y6kO0faJIa0On8gQ7JgnkSRM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.1"
+      }
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.0",
+        "shebang-command": "1.2.0",
+        "which": "1.2.14"
+      }
     },
     "cross-spawn-async": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
       "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.0",
+        "which": "1.2.14"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -1087,31 +1709,46 @@
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.2"
+      }
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "dargs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1131,13 +1768,20 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1161,19 +1805,36 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "strip-bom": "2.0.0"
+      }
     },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "del-cli": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/del-cli/-/del-cli-1.0.0.tgz",
       "integrity": "sha1-PP/B1QiyW1MscDucRQ5DlniZFi0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "del": "2.2.2",
+        "meow": "3.7.0",
+        "update-notifier": "2.2.0"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -1185,7 +1846,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "diff": {
       "version": "3.2.0",
@@ -1197,13 +1861,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "dot-prop": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
       "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
     },
     "double-ended-queue": {
       "version": "2.1.0-0",
@@ -1222,7 +1893,10 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "electron-to-chromium": {
       "version": "1.3.14",
@@ -1245,49 +1919,89 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1300,6 +2014,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -1318,7 +2039,10 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -1326,13 +2050,56 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.1.0",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.8.4",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "strip-bom": {
           "version": "3.0.0",
@@ -1344,7 +2111,10 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
         }
       }
     },
@@ -1358,19 +2128,31 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "object-assign": "4.1.1",
+        "resolve": "1.3.3"
+      }
     },
     "eslint-module-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
       "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "pkg-dir": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1385,36 +2167,70 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.3.0.tgz",
       "integrity": "sha1-N8gB4K2g4pbL3yDD85OstbUq82s=",
       "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.2.3",
+        "eslint-module-utils": "2.0.0",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
         },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
         },
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.3.8",
+            "path-type": "2.0.0"
+          }
         },
         "read-pkg-up": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -1428,7 +2244,11 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "5.0.3",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "3.1.3",
@@ -1440,13 +2260,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
+      "requires": {
+        "estraverse": "4.1.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
@@ -1472,19 +2299,34 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "exec-sh": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
       "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "merge": "1.2.0"
+      }
     },
     "execa": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
       "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn-async": "2.2.5",
+        "is-stream": "1.1.0",
+        "npm-run-path": "1.0.0",
+        "object-assign": "4.1.1",
+        "path-key": "1.0.0",
+        "strip-eof": "1.0.0"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -1496,13 +2338,19 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -1514,7 +2362,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extsprintf": {
       "version": "1.0.2",
@@ -1532,19 +2383,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bser": "2.0.0"
+      }
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1556,25 +2418,45 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "minimatch": "3.0.4"
+      }
     },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.6",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "locate-path": "2.0.0"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -1586,7 +2468,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1598,13 +2483,21 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "fs-access": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "null-check": "1.0.0"
+      }
     },
     "fs-readdir-recursive": {
       "version": "1.0.0",
@@ -1624,6 +2517,10 @@
       "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.33"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -1652,7 +2549,11 @@
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.2"
+          }
         },
         "asn1": {
           "version": "0.2.3",
@@ -1693,22 +2594,35 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "brace-expansion": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -1725,7 +2639,14 @@
           "version": "1.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -1735,13 +2656,19 @@
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
         },
         "commander": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -1762,13 +2689,19 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1782,7 +2715,10 @@
           "version": "2.2.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "deep-extend": {
           "version": "0.4.1",
@@ -1805,7 +2741,10 @@
           "version": "0.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -1834,7 +2773,12 @@
           "version": "2.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.14"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -1844,19 +2788,40 @@
         "fstream": {
           "version": "1.0.10",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.5.4"
+          }
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.10",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3"
+          }
         },
         "gauge": {
           "version": "2.7.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.0"
+          }
         },
         "generate-function": {
           "version": "2.0.0",
@@ -1868,13 +2833,19 @@
           "version": "1.2.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "is-property": "1.0.2"
+          }
         },
         "getpass": {
           "version": "0.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1887,7 +2858,15 @@
         "glob": {
           "version": "7.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -1904,13 +2883,22 @@
           "version": "2.0.6",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.9.0",
+            "is-my-json-valid": "2.15.0",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -1922,7 +2910,13 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
         },
         "hoek": {
           "version": "2.16.3",
@@ -1933,12 +2927,21 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.3.1",
+            "sshpk": "1.10.2"
+          }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -1954,13 +2957,22 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-my-json-valid": {
           "version": "2.15.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "jsonpointer": "4.0.1",
+            "xtend": "4.0.1"
+          }
         },
         "is-property": {
           "version": "1.0.2",
@@ -1989,7 +3001,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "jsbn": {
           "version": "0.1.1",
@@ -2019,7 +3034,12 @@
           "version": "1.3.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          }
         },
         "mime-db": {
           "version": "1.26.0",
@@ -2029,12 +3049,18 @@
         "mime-types": {
           "version": "2.1.14",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.26.0"
+          }
         },
         "minimatch": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.6"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -2044,7 +3070,10 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -2056,19 +3085,39 @@
           "version": "0.6.33",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.0.2",
+            "rc": "1.1.7",
+            "request": "2.79.0",
+            "rimraf": "2.5.4",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.3.0"
+          }
         },
         "nopt": {
           "version": "3.0.6",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0"
+          }
         },
         "npmlog": {
           "version": "4.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.2",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.3",
+            "set-blocking": "2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -2090,7 +3139,10 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -2107,7 +3159,10 @@
           "version": "2.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
         },
         "process-nextick-args": {
           "version": "1.0.7",
@@ -2131,6 +3186,12 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "0.4.1",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -2144,18 +3205,52 @@
           "version": "2.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
         },
         "request": {
           "version": "2.79.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.2",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.14",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.0.1"
+          }
         },
         "rimraf": {
           "version": "2.5.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.1"
+          }
         },
         "semver": {
           "version": "5.3.0",
@@ -2179,13 +3274,27 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "sshpk": {
           "version": "1.10.2",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.6",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -2203,7 +3312,12 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
@@ -2214,7 +3328,10 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -2231,25 +3348,52 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.10",
+            "inherits": "2.0.3"
+          }
         },
         "tar-pack": {
           "version": "3.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "debug": "2.2.0",
+            "fstream": "1.0.10",
+            "fstream-ignore": "1.0.5",
+            "once": "1.3.3",
+            "readable-stream": "2.1.5",
+            "rimraf": "2.5.4",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          },
           "dependencies": {
             "once": {
               "version": "1.3.3",
               "bundled": true,
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
             },
             "readable-stream": {
               "version": "2.1.5",
               "bundled": true,
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              }
             }
           }
         },
@@ -2257,7 +3401,10 @@
           "version": "2.3.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.4.3",
@@ -2292,13 +3439,19 @@
           "version": "1.3.6",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
         },
         "wide-align": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -2329,7 +3482,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -2341,7 +3497,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
       "integrity": "sha1-Q8a0wEi3XdYE/FOI7ezeVX9jNd8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.4.2",
+        "meow": "3.7.0",
+        "normalize-package-data": "2.3.8",
+        "parse-github-repo-url": "1.4.0",
+        "through2": "2.0.3"
+      }
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -2360,6 +3523,9 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2373,31 +3539,53 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/git-latest-semver-tag/-/git-latest-semver-tag-1.0.2.tgz",
       "integrity": "sha1-BhEwy/QnQRHMa+RhKz/zptk+JmA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "git-semver-tags": "1.2.0",
+        "meow": "3.7.0"
+      }
     },
     "git-raw-commits": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
       "integrity": "sha1-DzqL/ZmuDy2LkiTViJKXXppS0Dw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dargs": "4.1.0",
+        "lodash.template": "4.4.0",
+        "meow": "3.7.0",
+        "split2": "2.1.1",
+        "through2": "2.0.3"
+      }
     },
     "git-remote-origin-url": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gitconfiglocal": "1.0.0",
+        "pify": "2.3.0"
+      }
     },
     "git-semver-tags": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
       "integrity": "sha1-sx/QLIq1eL1sm1ysyl4cZMEXesE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "meow": "3.7.0",
+        "semver": "5.3.0"
+      }
     },
     "gitconfiglocal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ini": "1.3.4"
+      }
     },
     "github-url-from-git": {
       "version": "1.5.0",
@@ -2409,19 +3597,34 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -2433,13 +3636,34 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.0.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -2464,6 +3688,12 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.28"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -2475,7 +3705,10 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -2489,19 +3722,29 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -2513,7 +3756,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -2525,7 +3774,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "hosted-git-info": {
       "version": "2.4.2",
@@ -2537,13 +3790,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "1.0.1"
+      }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.13",
@@ -2573,13 +3834,20 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -2598,18 +3866,41 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -2623,7 +3914,10 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -2642,7 +3936,10 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -2654,13 +3951,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-ci": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ci-info": "1.0.0"
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2672,7 +3975,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -2690,7 +3996,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -2702,13 +4011,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-npm": {
       "version": "1.0.0",
@@ -2720,7 +4038,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-obj": {
       "version": "1.0.1",
@@ -2738,13 +4059,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -2780,7 +4107,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -2804,7 +4134,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "text-extensions": "1.5.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2840,7 +4173,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2852,7 +4188,20 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.9.tgz",
       "integrity": "sha512-zV14oa+hjBNP3gJTM/BzNdJpInHKbZ9cLIEwVasuaTUA1ebF9TBOIfcC5SDAE3C11rXxOw3KSimKGMiFz6PpWQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "2.4.1",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.0.7",
+        "istanbul-lib-instrument": "1.7.2",
+        "istanbul-lib-report": "1.1.1",
+        "istanbul-lib-source-maps": "1.2.1",
+        "istanbul-reports": "1.1.1",
+        "js-yaml": "3.8.4",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0"
+      }
     },
     "istanbul-lib-coverage": {
       "version": "1.1.1",
@@ -2864,25 +4213,46 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
       "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "append-transform": "0.4.0"
+      }
     },
     "istanbul-lib-instrument": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz",
       "integrity": "sha512-lPgUY+Pa5dlq2/l0qs1PJZ54QPSfo+s4+UZdkb2d0hbOyrEIAbUJphBLFjEyXBdeCONgGRADFzs3ojfFtmuwFA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.25.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3",
+        "istanbul-lib-coverage": "1.1.1",
+        "semver": "5.3.0"
+      }
     },
     "istanbul-lib-report": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
       "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "1.1.1",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.5",
+        "supports-color": "3.2.3"
+      },
       "dependencies": {
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -2890,19 +4260,32 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
       "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "istanbul-lib-coverage": "1.1.1",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "source-map": "0.5.6"
+      }
     },
     "istanbul-reports": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "handlebars": "4.0.10"
+      }
     },
     "jest": {
       "version": "20.0.4",
       "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
       "integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
       "dev": true,
+      "requires": {
+        "jest-cli": "20.0.4"
+      },
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
@@ -2914,7 +4297,39 @@
           "version": "20.0.4",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
           "integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "callsites": "2.0.0",
+            "chalk": "1.1.3",
+            "graceful-fs": "4.1.11",
+            "is-ci": "1.0.10",
+            "istanbul-api": "1.1.9",
+            "istanbul-lib-coverage": "1.1.1",
+            "istanbul-lib-instrument": "1.7.2",
+            "istanbul-lib-source-maps": "1.2.1",
+            "jest-changed-files": "20.0.3",
+            "jest-config": "20.0.4",
+            "jest-docblock": "20.0.3",
+            "jest-environment-jsdom": "20.0.3",
+            "jest-haste-map": "20.0.4",
+            "jest-jasmine2": "20.0.4",
+            "jest-message-util": "20.0.3",
+            "jest-regex-util": "20.0.3",
+            "jest-resolve-dependencies": "20.0.3",
+            "jest-runtime": "20.0.4",
+            "jest-snapshot": "20.0.3",
+            "jest-util": "20.0.3",
+            "micromatch": "2.3.11",
+            "node-notifier": "5.1.2",
+            "pify": "2.3.0",
+            "slash": "1.0.0",
+            "string-length": "1.0.1",
+            "throat": "3.1.0",
+            "which": "1.2.14",
+            "worker-farm": "1.3.1",
+            "yargs": "7.1.0"
+          }
         }
       }
     },
@@ -2928,13 +4343,31 @@
       "version": "20.0.4",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
       "integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "glob": "7.1.2",
+        "jest-environment-jsdom": "20.0.3",
+        "jest-environment-node": "20.0.3",
+        "jest-jasmine2": "20.0.4",
+        "jest-matcher-utils": "20.0.3",
+        "jest-regex-util": "20.0.3",
+        "jest-resolve": "20.0.4",
+        "jest-validate": "20.0.3",
+        "pretty-format": "20.0.3"
+      }
     },
     "jest-diff": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
       "integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "diff": "3.2.0",
+        "jest-matcher-utils": "20.0.3",
+        "pretty-format": "20.0.3"
+      }
     },
     "jest-docblock": {
       "version": "20.0.3",
@@ -2946,43 +4379,86 @@
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
       "integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jest-mock": "20.0.3",
+        "jest-util": "20.0.3",
+        "jsdom": "9.12.0"
+      }
     },
     "jest-environment-node": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
       "integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jest-mock": "20.0.3",
+        "jest-util": "20.0.3"
+      }
     },
     "jest-haste-map": {
       "version": "20.0.4",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
       "integrity": "sha1-ZT61XIic48Ah97lGk/IKQVm63wM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-docblock": "20.0.3",
+        "micromatch": "2.3.11",
+        "sane": "1.6.0",
+        "worker-farm": "1.3.1"
+      }
     },
     "jest-jasmine2": {
       "version": "20.0.4",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
       "integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "graceful-fs": "4.1.11",
+        "jest-diff": "20.0.3",
+        "jest-matcher-utils": "20.0.3",
+        "jest-matchers": "20.0.3",
+        "jest-message-util": "20.0.3",
+        "jest-snapshot": "20.0.3",
+        "once": "1.4.0",
+        "p-map": "1.1.1"
+      }
     },
     "jest-matcher-utils": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
       "integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "pretty-format": "20.0.3"
+      }
     },
     "jest-matchers": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
       "integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jest-diff": "20.0.3",
+        "jest-matcher-utils": "20.0.3",
+        "jest-message-util": "20.0.3",
+        "jest-regex-util": "20.0.3"
+      }
     },
     "jest-message-util": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
       "integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0"
+      }
     },
     "jest-mock": {
       "version": "20.0.3",
@@ -3000,19 +4476,44 @@
       "version": "20.0.4",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
       "integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browser-resolve": "1.11.2",
+        "is-builtin-module": "1.0.0",
+        "resolve": "1.3.3"
+      }
     },
     "jest-resolve-dependencies": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
       "integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "20.0.3"
+      }
     },
     "jest-runtime": {
       "version": "20.0.4",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
       "integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
       "dev": true,
+      "requires": {
+        "babel-core": "6.25.0",
+        "babel-jest": "20.0.3",
+        "babel-plugin-istanbul": "4.1.4",
+        "chalk": "1.1.3",
+        "convert-source-map": "1.5.0",
+        "graceful-fs": "4.1.11",
+        "jest-config": "20.0.4",
+        "jest-haste-map": "20.0.4",
+        "jest-regex-util": "20.0.3",
+        "jest-resolve": "20.0.4",
+        "jest-util": "20.0.3",
+        "json-stable-stringify": "1.0.1",
+        "micromatch": "2.3.11",
+        "strip-bom": "3.0.0",
+        "yargs": "7.1.0"
+      },
       "dependencies": {
         "strip-bom": {
           "version": "3.0.0",
@@ -3026,19 +4527,42 @@
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
       "integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "jest-diff": "20.0.3",
+        "jest-matcher-utils": "20.0.3",
+        "jest-util": "20.0.3",
+        "natural-compare": "1.4.0",
+        "pretty-format": "20.0.3"
+      }
     },
     "jest-util": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
       "integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "graceful-fs": "4.1.11",
+        "jest-message-util": "20.0.3",
+        "jest-mock": "20.0.3",
+        "jest-validate": "20.0.3",
+        "leven": "2.1.0",
+        "mkdirp": "0.5.1"
+      }
     },
     "jest-validate": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
       "integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "jest-matcher-utils": "20.0.3",
+        "leven": "2.1.0",
+        "pretty-format": "20.0.3"
+      }
     },
     "js-tokens": {
       "version": "3.0.1",
@@ -3050,7 +4574,11 @@
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -3064,6 +4592,27 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
+      "requires": {
+        "abab": "1.0.3",
+        "acorn": "4.0.13",
+        "acorn-globals": "3.1.0",
+        "array-equal": "1.0.0",
+        "content-type-parser": "1.0.1",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.8.1",
+        "html-encoding-sniffer": "1.0.1",
+        "nwmatcher": "1.4.0",
+        "parse5": "1.5.1",
+        "request": "2.81.0",
+        "sax": "1.2.2",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.2",
+        "webidl-conversions": "4.0.1",
+        "whatwg-encoding": "1.0.1",
+        "whatwg-url": "4.8.0",
+        "xml-name-validator": "2.0.1"
+      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -3089,7 +4638,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -3105,8 +4656,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -3124,13 +4674,23 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
       "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3144,13 +4704,19 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "package-json": "4.0.1"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -3163,7 +4729,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "leven": {
       "version": "2.1.0",
@@ -3175,25 +4744,52 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lint-staged": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-3.6.0.tgz",
       "integrity": "sha1-zajwvvFueSjMFLc1GGrhLNZiWZw=",
       "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "cosmiconfig": "1.1.0",
+        "execa": "0.6.3",
+        "listr": "0.12.0",
+        "lodash.chunk": "4.2.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.1.1",
+        "staged-git-files": "0.0.4"
+      },
       "dependencies": {
         "execa": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
           "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
         },
         "path-key": {
           "version": "2.0.1",
@@ -3207,7 +4803,25 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
       "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.2.0",
+        "listr-verbose-renderer": "0.4.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.1.1",
+        "rxjs": "5.4.0",
+        "stream-to-observable": "0.1.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
@@ -3220,6 +4834,16 @@
       "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
       "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.1.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
       "dependencies": {
         "indent-string": {
           "version": "3.1.0",
@@ -3233,24 +4857,46 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz",
       "integrity": "sha1-RNwBuww0oDxXIVTU0Izemx3FYg8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.28.5",
+        "figures": "1.7.0"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
     },
     "loader-utils": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0="
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "requires": {
+        "big.js": "3.1.3",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
+      }
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -3280,25 +4926,39 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
+      }
     },
     "lodash.templatesettings": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "3.0.0"
+      }
     },
     "log-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      }
     },
     "log-update": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
     },
     "longest": {
       "version": "1.0.1",
@@ -3310,13 +4970,20 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.1"
+      }
     },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -3328,19 +4995,29 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.0.tgz",
       "integrity": "sha512-aHGs865JXz6bkB4AHL+3AhyvTFKL3iZamKVWjIUKnXOXyasJvqPK8WAjOnAQKQZVpeXDVz19u1DD0r/12bWAdQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "make-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
       "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
     },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.4"
+      }
     },
     "map-obj": {
       "version": "1.0.1",
@@ -3353,6 +5030,18 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.3.8",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -3372,7 +5061,22 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "mime-db": {
       "version": "1.27.0",
@@ -3384,13 +5088,19 @@
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.7"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -3402,7 +5112,10 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "modify-values": {
       "version": "1.0.0",
@@ -3415,6 +5128,21 @@
       "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-1.1.0.tgz",
       "integrity": "sha1-l99L47wgjWI1GdahjxhAfveaoiY=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "cp-file": "4.2.0",
+        "js-yaml": "3.8.4",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "prop-ini": "0.0.2",
+        "readme-badger": "0.1.2",
+        "split-lines": "1.1.0",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "webpack-merge": "4.1.0",
+        "yarn-install": "0.2.1"
+      },
       "dependencies": {
         "strip-bom": {
           "version": "3.0.0",
@@ -3453,7 +5181,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.0.tgz",
       "integrity": "sha1-mLL/rvtGEPo5NvHnFDXTBwDeKEA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -3465,49 +5196,95 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "growly": "1.3.0",
+        "semver": "5.3.0",
+        "shellwords": "0.1.0",
+        "which": "1.2.14"
+      }
     },
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.4.2",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "npm-path": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
       "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "which": "1.2.14"
+      }
     },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
       "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-key": "1.0.0"
+      }
     },
     "npm-which": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "2.9.0",
+        "npm-path": "2.0.3",
+        "which": "1.2.14"
+      }
     },
     "nsp": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.6.3.tgz",
       "integrity": "sha1-2wUDWVPNoqs6Vx7oL6uE9MsIHRc=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-table": "0.3.1",
+        "cvss": "1.0.1",
+        "https-proxy-agent": "1.0.0",
+        "joi": "6.10.1",
+        "nodesecurity-npm-utils": "5.0.0",
+        "path-is-absolute": "1.0.0",
+        "rc": "1.1.6",
+        "semver": "5.1.0",
+        "subcommand": "2.0.3",
+        "wreck": "6.3.0"
+      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
@@ -3526,6 +5303,9 @@
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
@@ -3540,6 +5320,9 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
@@ -3562,6 +5345,9 @@
           "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
           "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
           "dev": true,
+          "requires": {
+            "colors": "1.0.3"
+          },
           "dependencies": {
             "colors": {
               "version": "1.0.3",
@@ -3582,12 +5368,21 @@
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
+          "requires": {
+            "agent-base": "2.0.1",
+            "debug": "2.2.0",
+            "extend": "3.0.0"
+          },
           "dependencies": {
             "agent-base": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
               "integrity": "sha1-vY+ehqjrIh//oHvRS+/VXfFCgV4=",
               "dev": true,
+              "requires": {
+                "extend": "3.0.0",
+                "semver": "5.0.3"
+              },
               "dependencies": {
                 "semver": {
                   "version": "5.0.3",
@@ -3602,6 +5397,9 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
               "dev": true,
+              "requires": {
+                "ms": "0.7.1"
+              },
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
@@ -3624,6 +5422,12 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
           "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
           "dev": true,
+          "requires": {
+            "hoek": "2.16.3",
+            "isemail": "1.2.0",
+            "moment": "2.12.0",
+            "topo": "1.1.0"
+          },
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
@@ -3647,7 +5451,10 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
               "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
             }
           }
         },
@@ -3668,6 +5475,12 @@
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
           "dev": true,
+          "requires": {
+            "deep-extend": "0.4.1",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "1.0.4"
+          },
           "dependencies": {
             "deep-extend": {
               "version": "0.4.1",
@@ -3706,6 +5519,12 @@
           "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
           "integrity": "sha1-mz/Rp1PjxEHwBBDLRBMdhlX1LDI=",
           "dev": true,
+          "requires": {
+            "cliclopts": "1.1.1",
+            "debug": "2.2.0",
+            "minimist": "1.2.0",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "cliclopts": {
               "version": "1.1.1",
@@ -3718,6 +5537,9 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
               "dev": true,
+              "requires": {
+                "ms": "0.7.1"
+              },
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
@@ -3746,12 +5568,19 @@
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
           "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
           "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "hoek": "2.16.3"
+          },
           "dependencies": {
             "boom": {
               "version": "2.10.1",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
             },
             "hoek": {
               "version": "2.16.3",
@@ -3797,13 +5626,20 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -3816,6 +5652,10 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
@@ -3829,13 +5669,27 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "ora": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -3847,7 +5701,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "os-shim": {
       "version": "0.1.3",
@@ -3865,7 +5722,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -3883,7 +5745,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
     },
     "p-map": {
       "version": "1.1.1",
@@ -3895,7 +5760,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.1",
+        "registry-url": "3.1.0",
+        "semver": "5.3.0"
+      }
     },
     "parse-github-repo-url": {
       "version": "1.4.0",
@@ -3907,13 +5778,22 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "parse5": {
       "version": "1.5.1",
@@ -3955,7 +5835,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "performance-now": {
       "version": "0.2.0",
@@ -3979,25 +5864,38 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pkg-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      },
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
         }
       }
     },
@@ -4011,7 +5909,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
       "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -4036,12 +5939,19 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
       "integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
       "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1",
+        "ansi-styles": "3.0.0"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.0.0.tgz",
           "integrity": "sha1-VATpOlRMT+x/BIJil3vr/jFV4ME=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
         }
       }
     },
@@ -4067,7 +5977,10 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/prop-ini/-/prop-ini-0.0.2.tgz",
       "integrity": "sha1-ZzOny1JCrKsr5C5gdYPYEksXKls=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1"
+      }
     },
     "prr": {
       "version": "0.0.0",
@@ -4103,13 +6016,23 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "kind-of": "3.2.2"
+      }
     },
     "rc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -4123,25 +6046,41 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.3.8",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      },
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
         }
       }
     },
@@ -4149,26 +6088,49 @@
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
       "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.0.1",
+        "string_decoder": "1.0.2",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.2.11",
+        "set-immediate-shim": "1.0.1"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         }
       }
     },
@@ -4182,13 +6144,20 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
     },
     "regenerate": {
       "version": "1.3.2",
@@ -4206,31 +6175,52 @@
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
       "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "private": "0.1.7"
+      }
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.2",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
     },
     "registry-auth-token": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rc": "1.2.1",
+        "safe-buffer": "5.0.1"
+      }
     },
     "registry-url": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rc": "1.2.1"
+      }
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -4243,6 +6233,9 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
@@ -4274,13 +6267,40 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.0.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.0.1"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -4304,13 +6324,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -4322,26 +6349,39 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -4353,7 +6393,10 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.0.tgz",
       "integrity": "sha1-p9sUqxV/nXqsalbmVeejhg05vyY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.4"
+      }
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -4366,18 +6409,33 @@
       "resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
       "integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
       "dev": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "exec-sh": "0.2.0",
+        "fb-watchman": "1.9.2",
+        "minimatch": "3.0.4",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.10.0"
+      },
       "dependencies": {
         "bser": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
           "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "node-int64": "0.4.0"
+          }
         },
         "fb-watchman": {
           "version": "1.9.2",
           "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
           "integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "bser": "1.0.2"
+          }
         },
         "minimist": {
           "version": "1.2.0",
@@ -4393,6 +6451,14 @@
       "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg=",
       "dev": true
     },
+    "schema-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+      "requires": {
+        "ajv": "4.11.8"
+      }
+    },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -4403,7 +6469,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "semver": "5.3.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -4422,7 +6491,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -4434,7 +6506,12 @@
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.0",
@@ -4470,7 +6547,10 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "source-map": {
       "version": "0.5.6",
@@ -4482,19 +6562,29 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "spawn-sync": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "os-shim": "0.1.3"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -4512,7 +6602,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
       "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "split-lines": {
       "version": "1.1.0",
@@ -4524,7 +6617,10 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
       "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through2": "2.0.3"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -4537,6 +6633,16 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -4557,6 +6663,16 @@
       "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.0.0.tgz",
       "integrity": "sha1-5XjO/UOrewKUS9dWlSUFLqwbl4c=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "conventional-changelog": "1.1.3",
+        "conventional-recommended-bump": "0.3.0",
+        "figures": "1.7.0",
+        "fs-access": "1.0.1",
+        "object-assign": "4.1.1",
+        "semver": "5.3.0",
+        "yargs": "6.6.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -4568,31 +6684,62 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "yargs": {
           "version": "6.6.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
         },
         "yargs-parser": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
         }
       }
     },
@@ -4606,19 +6753,29 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
       "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
     },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "strip-ansi": "3.0.1"
+      }
     },
     "string-width": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
       "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -4630,13 +6787,19 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -4648,7 +6811,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -4684,19 +6850,37 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.0.0"
+      }
     },
     "term-size": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
       "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "execa": "0.4.0"
+      }
     },
     "test-exclude": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "require-main-filename": "1.0.1"
+      }
     },
     "text-extensions": {
       "version": "1.5.0",
@@ -4714,7 +6898,10 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-3.1.0.tgz",
       "integrity": "sha512-AvehafrUS8C2PWA4YgPsPV6qrM5e7yU7o7jpuRzXVjRcPrPQgBsL6lVFxHXZEtRjZTdF+J9S2dIUxbheUrxAHA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "double-ended-queue": "2.1.0-0"
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -4726,7 +6913,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.2.11",
+        "xtend": "4.0.1"
+      }
     },
     "timed-out": {
       "version": "4.0.1",
@@ -4750,7 +6941,10 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "tr46": {
       "version": "0.0.3",
@@ -4786,7 +6980,10 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -4799,7 +6996,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -4813,6 +7013,11 @@
       "integrity": "sha512-WqKNbmNJKzIdIEQu/U2ytgGBbhCy2PVks94GoetczOAJ/zCgVu2CuO7gguI5KPFGPtUtI1dmPQl6h0D4cPzypA==",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -4826,7 +7031,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -4841,7 +7052,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "1.0.0"
+      }
     },
     "unzip-response": {
       "version": "2.0.1",
@@ -4853,13 +7067,26 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
       "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boxen": "1.1.0",
+        "chalk": "1.1.3",
+        "configstore": "3.1.0",
+        "import-lazy": "2.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      }
     },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
     },
     "user-home": {
       "version": "1.1.1",
@@ -4883,25 +7110,38 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.11"
+      }
     },
     "watch": {
       "version": "0.10.0",
@@ -4919,25 +7159,39 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/webpack-defaults/-/webpack-defaults-1.3.0.tgz",
       "integrity": "sha512-qvTzSKLKqMFyI23xEBAfxHqkJ9HRAsFTrnwo/d9U4nPk9TD2fk9vEU7dIxpHXRoaQVIyfvEjEx2B+AMdTlFXTg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "mrm-core": "1.1.0"
+      }
     },
     "webpack-merge": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.0.tgz",
       "integrity": "sha1-atciI7PguDflMeRZfBmfkJNhUR4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "whatwg-encoding": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.13"
+      }
     },
     "whatwg-url": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
+      "requires": {
+        "tr46": "0.0.3",
+        "webidl-conversions": "3.0.1"
+      },
       "dependencies": {
         "webidl-conversions": {
           "version": "3.0.1",
@@ -4951,7 +7205,10 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "which-module": {
       "version": "1.0.0",
@@ -4964,18 +7221,29 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -4996,25 +7264,41 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
       "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "xtend": "4.0.1"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -5028,13 +7312,21 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
       "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
     },
     "xdg-basedir": {
       "version": "3.0.0",
@@ -5071,6 +7363,21 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "5.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -5082,19 +7389,32 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -5103,6 +7423,9 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -5117,12 +7440,21 @@
       "resolved": "https://registry.npmjs.org/yarn-install/-/yarn-install-0.2.1.tgz",
       "integrity": "sha1-Q4QcEtcJmkgfifv6bKSdO/ktFeM=",
       "dev": true,
+      "requires": {
+        "cac": "3.0.4",
+        "chalk": "1.1.3",
+        "cross-spawn": "4.0.2"
+      },
       "dependencies": {
         "cross-spawn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.0",
+            "which": "1.2.14"
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,20 @@
   "version": "1.0.0",
   "author": "Tobias Koppers @sokra",
   "description": "file loader module for webpack",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 4.3 < 5.0.0 || >= 5.10"
+  },
+  "main": "dist/cjs.js",
   "files": [
     "dist"
   ],
+  "directories": {
+    "test": "test"
+  },
   "dependencies": {
-    "loader-utils": "^1.0.2"
+    "loader-utils": "^1.0.2",
+    "schema-utils": "^0.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -33,7 +42,7 @@
   "scripts": {
     "start": "npm run build -- -w",
     "appveyor:test": "npm run test",
-    "build": "cross-env NODE_ENV=production babel src -d dist --ignore 'src/**/*.test.js'",
+    "build": "cross-env NODE_ENV=production babel src -d dist --ignore 'src/**/*.test.js' --copy-files",
     "clean": "del-cli dist",
     "lint": "eslint --cache src test",
     "lint-staged": "lint-staged",
@@ -57,14 +66,6 @@
     "url": "https://github.com/webpack/file-loader/issues"
   },
   "homepage": "https://github.com/webpack/file-loader",
-  "main": "dist/cjs.js",
-  "directories": {
-    "test": "test"
-  },
-  "license": "MIT",
-  "engines": {
-    "node": ">= 4.3 < 5.0.0 || >= 5.10"
-  },
   "pre-commit": "lint-staged",
   "lint-staged": {
     "*.js": [

--- a/src/options.json
+++ b/src/options.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "regExp": {},
+    "context": {
+      "type": "string"
+    },
+    "publicPath": {},
+    "outputPath": {},
+    "useRelativePath": {
+      "type": "boolean"
+    },
+    "emitFile": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -1,0 +1,17 @@
+import loader from '../src';
+
+describe('Errors', () => {
+  test('Validation Error', () => {
+    const err = () => loader.call({ query: { name: 1 }, emitFile: true });
+
+    expect(err).toThrow();
+    expect(err).toThrowErrorMatchingSnapshot();
+  });
+
+  test('Loader Error', () => {
+    const err = () => loader.call({ emitFile: false });
+
+    expect(err).toThrow();
+    expect(err).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/__snapshots__/Errors.test.js.snap
+++ b/test/__snapshots__/Errors.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Errors Loader Error 1`] = `
+"File Loader
+
+emitFile is required from module system"
+`;
+
+exports[`Errors Validation Error 1`] = `
+"Validation Error
+
+File Loader Invalid Options
+
+options.name should be string
+"
+`;

--- a/test/emitFile.test.js
+++ b/test/emitFile.test.js
@@ -1,10 +1,11 @@
-import fileLoader from '../src';
+import loader from '../src';
 
 const run = function run(resourcePath, query, content = new Buffer('1234')) {
   let result = false;
+
   const context = {
     resourcePath,
-    query: `?${query}`,
+    query: `?${query || ''}`,
     options: {
       context: '/this/is/the/context',
     },
@@ -12,7 +13,9 @@ const run = function run(resourcePath, query, content = new Buffer('1234')) {
       result = true;
     },
   };
-  fileLoader.call(context, content);
+
+  loader.call(context, content);
+
   return result;
 };
 

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-useless-escape, no-unused-vars */
-import fileLoader from '../src';
+import loader from '../src';
 
 const run = function run(resourcePath, query, content = new Buffer('1234')) {
   let file = null;
 
   const context = {
     resourcePath,
-    query: `?${query}`,
+    query: `?${query || ''}`,
     options: {
       context: '/this/is/the/context',
     },
@@ -16,7 +16,7 @@ const run = function run(resourcePath, query, content = new Buffer('1234')) {
     },
   };
 
-  const result = fileLoader.call(context, content);
+  const result = loader.call(context, content);
 
   return {
     file,
@@ -29,8 +29,8 @@ function runWithOptions(resourcePath, options, content = new Buffer('1234')) {
 
   const context = {
     resourcePath,
+    query: options,
     options: {
-      fileLoader: options,
       context: '/this/is/the/context',
     },
     emitFile(url, content2) {
@@ -39,7 +39,7 @@ function runWithOptions(resourcePath, options, content = new Buffer('1234')) {
     },
   };
 
-  const result = fileLoader.call(context, content);
+  const result = loader.call(context, content);
 
   return {
     file,
@@ -57,6 +57,7 @@ describe('correct-filename', () => {
     test('81dc9bdb52d04dc20036dbd8313ed055.txt', 'file.txt', '');
     test('81dc9bdb52d04dc20036dbd8313ed055.bin', '', '');
   });
+
   it('should process name correctly', () => {
     test('file.txt', '/file.txt', 'name=[name].[ext]');
     test('file.png', '/file.png', 'name=[name].[ext]');
@@ -71,9 +72,11 @@ describe('correct-filename', () => {
     test('_/_/dir/sub/file.txt', '/this/is/dir/sub/file.txt', 'name=[path][name].[ext]');
     test('dir/sub/file.txt', '/this/is/dir/sub/file.txt', 'name=[path][name].[ext]&context=/this/is');
   });
+
   it('should process hash correctly', () => {
     test('d93591bdf7860e1e4ee2fca799911215.txt', '/file.txt', '', new Buffer('4321'));
   });
+
   it('should process hash options correctly', () => {
     test('81dc9.txt', '/file.txt', 'name=[hash:5].[ext]');
     test('d4045.txt', '/file.txt', 'name=[sha512:hash:5].[ext]');
@@ -90,11 +93,13 @@ describe('publicPath option', () => {
       'export default "http://cdn/81dc9bdb52d04dc20036dbd8313ed055.txt";',
     );
   });
+
   it('should override public path when given empty string', () => {
     expect(run('/file.txt', 'publicPath=').result).toEqual(
       'export default "81dc9bdb52d04dc20036dbd8313ed055.txt";',
     );
   });
+
   it('should use webpack public path when not set', () => {
     expect(run('/file.txt').result).toEqual(
       'export default __webpack_public_path__ + "81dc9bdb52d04dc20036dbd8313ed055.txt";',
@@ -107,12 +112,15 @@ describe('useRelativePath option', () => {
     expect(run('/this/is/the/context/file.txt', 'useRelativePath=true').result).toEqual(
       'export default __webpack_public_path__ + \"./81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
+
     expect(run('/this/is/file.txt', 'useRelativePath=true').result).toEqual(
       'export default __webpack_public_path__ + \"../../81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
+
     expect(run('/this/file.txt', 'context=/this/is/the/&useRelativePath=true').result).toEqual(
       'export default __webpack_public_path__ + \"../../81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
+
     expect(run('/this/file.txt', 'context=/&useRelativePath=true').result).toEqual(
       'export default __webpack_public_path__ + \"this/81dc9bdb52d04dc20036dbd8313ed055.txt\";',
     );
@@ -121,20 +129,23 @@ describe('useRelativePath option', () => {
 
 describe('outputPath function', () => {
   it('should be supported', () => {
-    const outputFunc = value => '/path/set/by/func';
     const options = {};
-    options.outputPath = outputFunc;
-    expect(runWithOptions('/this/is/the/context/file.txt', options).result).toEqual(
-      'export default __webpack_public_path__ + \"/path/set/by/func\";',
-    );
+    options.outputPath = value => '/path/set/by/func';
+
+    expect(runWithOptions('/this/is/the/context/file.txt', options).result)
+      .toEqual(
+        'export default __webpack_public_path__ + \"/path/set/by/func\";',
+      );
   });
+
   it('should be ignored if you set useRelativePath', () => {
-    const outputFunc = value => '/path/set/by/func';
     const options = {};
-    options.outputPath = outputFunc;
+    options.outputPath = value => '/path/set/by/func';
     options.useRelativePath = true;
-    expect(runWithOptions('/this/is/the/context/file.txt', options).result).toEqual(
-      'export default __webpack_public_path__ + \"./81dc9bdb52d04dc20036dbd8313ed055.txt\";',
-    );
+
+    expect(runWithOptions('/this/is/the/context/file.txt', options).result)
+      .toEqual(
+        'export default __webpack_public_path__ + \"./81dc9bdb52d04dc20036dbd8313ed055.txt\";',
+      );
   });
 });


### PR DESCRIPTION
### Notable Changes

This PR removes the obsolete options handling for `this.options.fileLoader` (`webpack =< v1.0.0`)

**webpack.config.js**
```js
const config = {
  module: {
    loaders: [
     { 
        test: /\.(png|jpg)$/,
        loader: 'file-loader'
      }
    ]
  },
  fileLoader: {...options} // Invalid in webpack >= v2.0.0
}
```