### PR TITLE
fix: "raw = true" was not used by webpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,4 +78,4 @@ export default function fileLoader(content) {
   return `export default ${publicPath};`;
 }
 
-export const raw = true;
+fileLoader.raw = true;


### PR DESCRIPTION
## Error description
https://gist.github.com/dkwingsmt/7325377c3758f7779e9848c5297893e9 contains the error description and a minimal sample.

This error does not occur if using file-loader@^0.11.

## Error explanation
According to https://github.com/webpack/loader-runner/blob/master/lib/loadLoader.js#L33 , the property `raw` of `module` is used, but variable `module` there turns out to be the function, instead of the imported module as a whole.

Since Webpack does not see a `raw` flag, it will convert the input stream to UTF8, hence corrupting the binary file.

## Environment
- node: v6.11.2
- npm: v3.10.10
- OS: macOS 10.12.6