### PR TITLE
docs(README): add missing leading slash in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can specify custom `output` and `public` paths by using `outputPath`, `publi
   loader: 'file-loader',
   options: {
     name: '[path][name].[ext]',
-    publicPath: 'assets'
+    publicPath: 'assets/'
   }  
 }
 ```
@@ -136,7 +136,7 @@ You can specify custom `output` and `public` paths by using `outputPath`, `publi
   loader: 'file-loader',
   options: {
     name: '[path][name].[ext]',
-    outputPath: 'images'
+    outputPath: 'images/'
   }  
 }
 ```


### PR DESCRIPTION
The current documentation is incorrect, or at least misleading. For `publicPath` or `outputPath`, if you omit the leading slash, no directory is created, and the files are placed in `output.path` as usual.

If this is the desired behavior, it should be documented as such; if it's not, I'm happy to submit a PR to `file-loader` which would make it care less about whether there's a trailing slash.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
