### PR TITLE
Update minimum required Node.js version to 4.8

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
       {
         "useBuiltIns": true,
         "targets": {
-          "node": "4.3"
+          "node": "4.8"
         },
         "exclude": [
           "transform-async-to-generator",

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       node_js: '8'
       env: WEBPACK_VERSION="2.6.0" JOB_PART=lint
     - os: linux
-      node_js: '4.3'
+      node_js: '4.8'
       env: WEBPACK_VERSION="2.6.0" JOB_PART=test
     - os: linux
       node_js: '6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - nodejs_version: '6'
       webpack_version: 2.6.0
       job_part: test
-    - nodejs_version: '4.3'
+    - nodejs_version: '4.8'
       webpack_version: 2.6.0
       job_part: test
 build: 'off'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "file loader module for webpack",
   "license": "MIT",
   "engines": {
-    "node": ">= 4.3 < 5.0.0 || >= 5.10"
+    "node": ">= 4.8 < 5.0.0 || >= 5.10"
   },
   "main": "dist/cjs.js",
   "files": [


### PR DESCRIPTION
As described in https://github.com/npm/npm/issues/18395 , npm 5.4 is incompatible with Node.js 4.3. Furthermore, per https://github.com/nodejs/Release , Node.js 4.3 is no longer supported, only the latest 4.x release (currently 4.8) is still in LTS.

This change will ensure that all `file-loader` tests will start passing again, while keeping support for the broadest possible range of Node.js versions.
