### PR TITLE
fix(schema): allow `name` to be a `{Function}` (`options.name`)

### DIFF
--- a/src/options.json
+++ b/src/options.json
@@ -1,9 +1,7 @@
 {
   "type": "object",
   "properties": {
-    "name": {
-      "type": "string"
-    },
+    "name": {},
     "regExp": {},
     "context": {
       "type": "string"

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -2,7 +2,10 @@ import loader from '../src';
 
 describe('Errors', () => {
   test('Validation Error', () => {
-    const err = () => loader.call({ query: { name: 1 }, emitFile: true });
+    const err = () => loader.call({
+      query: { useRelativePath: 1 },
+      emitFile: true,
+    });
 
     expect(err).toThrow();
     expect(err).toThrowErrorMatchingSnapshot();

--- a/test/__snapshots__/Errors.test.js.snap
+++ b/test/__snapshots__/Errors.test.js.snap
@@ -11,6 +11,6 @@ exports[`Errors Validation Error 1`] = `
 
 File Loader Invalid Options
 
-options.name should be string
+options.useRelativePath should be boolean
 "
 `;


### PR DESCRIPTION
### Notable Changes
---

[loaderUtils#interpolateName](https://github.com/webpack/loader-utils/blob/master/lib/interpolateName.js#L27) accepts a `{Function}` for `name`

### Issues
---

- Fixes #215 