### PR TITLE
refactor: function parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,11 @@ export default function loader(content) {
   });
 
   let outputPath = '';
-  const filePath = this.resourcePath;
 
   if (options.outputPath) {
     // support functions as outputPath to generate them dynamically
     outputPath = (
-      typeof options.outputPath === 'function' ? options.outputPath(url, filePath) : options.outputPath
+      typeof options.outputPath === 'function' ? options.outputPath(url, this.resourcePath) : options.outputPath
     );
   }
 
@@ -32,7 +31,7 @@ export default function loader(content) {
     const issuerContext = (this._module && this._module.issuer
       && this._module.issuer.context) || context;
 
-    const relativeUrl = issuerContext && path.relative(issuerContext, filePath).split(path.sep).join('/');
+    const relativeUrl = issuerContext && path.relative(issuerContext, this.resourcePath).split(path.sep).join('/');
 
     const relativePath = relativeUrl && `${path.dirname(relativeUrl)}/`;
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,14 +36,11 @@ export default function loader(content) {
 
     const relativePath = relativeUrl && `${path.dirname(relativeUrl)}/`;
 
-    // do not override outputPath if it's set
-    if (!outputPath) {
-      // eslint-disable-next-line no-bitwise
-      if (~relativePath.indexOf('../')) {
-        outputPath = path.posix.join(outputPath, relativePath, url);
-      } else {
-        outputPath = relativePath + url;
-      }
+    // eslint-disable-next-line no-bitwise
+    if (~relativePath.indexOf('../')) {
+      outputPath = path.posix.join(outputPath, relativePath, url);
+    } else {
+      outputPath = relativePath + url;
     }
 
     url = relativePath + url;

--- a/src/index.js
+++ b/src/index.js
@@ -19,15 +19,14 @@ export default function loader(content) {
   });
 
   let outputPath = '';
+  const filePath = this.resourcePath;
 
   if (options.outputPath) {
     // support functions as outputPath to generate them dynamically
     outputPath = (
-      typeof options.outputPath === 'function' ? options.outputPath(url) : options.outputPath
+      typeof options.outputPath === 'function' ? options.outputPath(url, filePath) : options.outputPath
     );
   }
-
-  const filePath = this.resourcePath;
 
   if (options.useRelativePath) {
     const issuerContext = (this._module && this._module.issuer
@@ -36,18 +35,19 @@ export default function loader(content) {
     const relativeUrl = issuerContext && path.relative(issuerContext, filePath).split(path.sep).join('/');
 
     const relativePath = relativeUrl && `${path.dirname(relativeUrl)}/`;
-    // eslint-disable-next-line no-bitwise
-    if (~relativePath.indexOf('../')) {
-      outputPath = path.posix.join(outputPath, relativePath, url);
-    } else {
-      outputPath = relativePath + url;
+
+    // do not override outputPath if it's set
+    if (!outputPath) {
+      // eslint-disable-next-line no-bitwise
+      if (~relativePath.indexOf('../')) {
+        outputPath = path.posix.join(outputPath, relativePath, url);
+      } else {
+        outputPath = relativePath + url;
+      }
     }
 
     url = relativePath + url;
   } else if (options.outputPath) {
-    // support functions as outputPath to generate them dynamically
-    outputPath = typeof options.outputPath === 'function' ? options.outputPath(url) : options.outputPath + url;
-
     url = outputPath;
   } else {
     outputPath = url;

--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,12 @@ export default function loader(content) {
   });
 
   let outputPath = '';
+  const filePath = this.resourcePath;
 
   if (options.outputPath) {
     // support functions as outputPath to generate them dynamically
     outputPath = (
-      typeof options.outputPath === 'function' ? options.outputPath(url, this.resourcePath) : options.outputPath
+      typeof options.outputPath === 'function' ? options.outputPath(url, filePath) : options.outputPath
     );
   }
 
@@ -31,15 +32,18 @@ export default function loader(content) {
     const issuerContext = (this._module && this._module.issuer
       && this._module.issuer.context) || context;
 
-    const relativeUrl = issuerContext && path.relative(issuerContext, this.resourcePath).split(path.sep).join('/');
+    const relativeUrl = issuerContext && path.relative(issuerContext, filePath).split(path.sep).join('/');
 
     const relativePath = relativeUrl && `${path.dirname(relativeUrl)}/`;
 
-    // eslint-disable-next-line no-bitwise
-    if (~relativePath.indexOf('../')) {
-      outputPath = path.posix.join(outputPath, relativePath, url);
-    } else {
-      outputPath = relativePath + url;
+    // do not override outputPath if it's set
+    if (!outputPath) {
+      // eslint-disable-next-line no-bitwise
+      if (~relativePath.indexOf('../')) {
+        outputPath = path.posix.join(outputPath, relativePath, url);
+      } else {
+        outputPath = relativePath + url;
+      }
     }
 
     url = relativePath + url;


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

* Pass the full filePath into `outputPath` function. Use this parameter, user can generate more dynamic output path
* Do not override 'outputPath' if user have set it