### PR TITLE
feat(index): add `dynamicPublicPath` option (`options.dynamicPublicPath`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module.exports = {
         use: [
           {
             loader: 'file-loader',
-            options: {}  
+            options: {}
           }
         ]
       }
@@ -60,6 +60,7 @@ Emits `file.png` as file in the output directory and returns the public URL
 |**`name`**|`{String\|Function}`|`[hash].[ext]`|Configure a custom filename template for your file|
 |**`context`**|`{String}`|`this.options.context`|Configure a custom file context, defaults to `webpack.config.js` [context](https://webpack.js.org/configuration/entry-context/#context)|
 |**`publicPath`**|`{String\|Function}`|[`__webpack_public_path__ `](https://webpack.js.org/api/module-variables/#__webpack_public_path__-webpack-specific-)|Configure a custom `public` path for your files|
+|**`dynamicPublicPath`**|`{Function}`|`'undefined'`|Similar to `publicPath`, but does not stringify the return value|
 |**`outputPath`**|`{String\|Function}`|`'undefined'`|Configure a custom `output` path for your files|
 |**`useRelativePath`**|`{Boolean}`|`false`|Should be `true` if you wish to generate a `context` relative URL for each file|
 |**`emitFile`**|`{Boolean}`|`true`|By default a file is emitted, however this can be disabled if required (e.g. for server side packages)|
@@ -76,7 +77,7 @@ You can configure a custom filename template for your file using the query param
   loader: 'file-loader',
   options: {
     name: '[path][name].[ext]'
-  }  
+  }
 }
 ```
 
@@ -94,7 +95,7 @@ You can configure a custom filename template for your file using the query param
 
       return '[hash].[ext]'
     }
-  }  
+  }
 }
 ```
 
@@ -129,11 +130,11 @@ By default, the path and name you specify will output the file in that same dire
   options: {
     name: '[path][name].[ext]',
     context: ''
-  }  
+  }
 }
 ```
 
-You can specify custom `output` and `public` paths by using `outputPath`, `publicPath` and `useRelativePath`
+You can specify custom `output` and `public` paths by using `outputPath`, `publicPath`, `dynamicPublicPath` and `useRelativePath`
 
 ### `publicPath`
 
@@ -144,7 +145,22 @@ You can specify custom `output` and `public` paths by using `outputPath`, `publi
   options: {
     name: '[path][name].[ext]',
     publicPath: 'assets/'
-  }  
+  }
+}
+```
+
+### `dynamicPublicPath`
+
+**webpack.config.js**
+```js
+{
+  loader: 'file-loader',
+  options: {
+    name: '[path][name].[ext]',
+    dynamicPublicPath: function(url) {
+      return `window.SomeVariable + "/${AnotherVariable}/" + ${JSON.stringify(url)}`;
+    }
+  }
 }
 ```
 
@@ -157,7 +173,7 @@ You can specify custom `output` and `public` paths by using `outputPath`, `publi
   options: {
     name: '[path][name].[ext]',
     outputPath: 'images/'
-  }  
+  }
 }
 ```
 
@@ -187,7 +203,7 @@ import img from './file.png'
   loader: 'file-loader',
   options: {
     emitFile: false
-  }  
+  }
 }
 ```
 
@@ -210,7 +226,7 @@ import png from 'image.png'
   loader: 'file-loader',
   options: {
     name: 'dirname/[hash].[ext]'
-  }  
+  }
 }
 ```
 
@@ -224,7 +240,7 @@ dirname/0dcbbaa701328ae351f.png
   loader: 'file-loader',
   options: {
     name: '[sha512:hash:base64:7].[ext]'
-  }  
+  }
 }
 ```
 
@@ -242,7 +258,7 @@ import png from 'path/to/file.png'
   loader: 'file-loader',
   options: {
     name: '[path][name].[ext]?[hash]'
-  }  
+  }
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,10 @@ export default function loader(content) {
     );
   }
 
+  if (options.dynamicPublicPath !== undefined) {
+    publicPath = typeof options.dynamicPublicPath === 'function' ? options.dynamicPublicPath(url) : publicPath;
+  }
+
   if (options.emitFile === undefined || options.emitFile) {
     this.emitFile(outputPath, content);
   }

--- a/src/options.json
+++ b/src/options.json
@@ -7,6 +7,7 @@
       "type": "string"
     },
     "publicPath": {},
+    "dynamicPublicPath": {},
     "outputPath": {},
     "useRelativePath": {
       "type": "boolean"

--- a/test/options/__snapshots__/dynamicPublicPath.test.js.snap
+++ b/test/options/__snapshots__/dynamicPublicPath.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Options dynamicPublicPath {Function} 1`] = `"throw new Error(\\"Module parse failed: /Users/anvar/projects/quanttech/file-loader/src/index.js??ref--0!/Users/anvar/projects/quanttech/file-loader/test/fixtures/file.png Identifier directly after number (1:23)\\\\nYou may need an appropriate loader to handle this file type.\\\\n| module.exports = test/9c87cbf3ba33126ffd25ae7f2f6bbafb.png;\\");"`;

--- a/test/options/dynamicPublicPath.test.js
+++ b/test/options/dynamicPublicPath.test.js
@@ -1,0 +1,26 @@
+/* eslint-disable
+  prefer-destructuring,
+*/
+import webpack from '../helpers/compiler';
+
+describe('Options', () => {
+  describe('dynamicPublicPath', () => {
+    test('{Function}', async () => {
+      const config = {
+        loader: {
+          test: /(png|jpg|svg)/,
+          options: {
+            dynamicPublicPath(url) {
+              return `test/${url}`;
+            },
+          },
+        },
+      };
+
+      const stats = await webpack('fixture.js', config);
+      const { source } = stats.toJson().modules[1];
+
+      expect(source).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Not sure if this is of any value for the community, but thought I would share it anyway.

This is to do with utilising a CDN on a separate domain from the main one. In my particular scenario the base URL is fetched from a remote service before loading assets. The base URL is stored in `window` and when resolving asset urls it must be prepended to form an absolute url. `publicPath` almost fits the bill, but it runs the return value through `JSON.stringify`, which makes it unsuitable for my use case.