### PR TITLE
Allow any version of webpack as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "webpack-defaults": "^1.6.0"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "*"
   },
   "scripts": {
     "start": "npm run build -- -w",


### PR DESCRIPTION
Webpack 4 alpha has been released. In preparation for v4,
it seems reasonable to change this to allow *. This should cut
down on maintenance and avoid unnecessarily blocking folks
from updating going forward.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
