### PR TITLE
docs: add outputPath edge case explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,27 @@ You can specify custom `output` and `public` paths by using `outputPath`, `publi
 }
 ```
 
+Keep in mind that when setting up the `outputPath` you will specify a path **relative** to the `path` entry in the `output` object of your configuration. To give you an example, if your webpack is setup as follows:
+
+```js
+...
+output: {
+  path: path.join(__dirname, '../public/js/'),
+  filename: 'bundle.[hash:8].js',
+}
+```
+You are trying to emit your `js` assets in `/public/js/`, now you might want to have other assets like images in `/public/images/`, in this case your `file-loader` configuration will look something like this:
+```js
+{
+  loader: 'file-loader',
+  options: {
+    name: '[path][name].[ext]',
+    outputPath: '../images/'
+  }  
+}
+```
+This is necessary because you need to navigate one level up from `/public/js/` in order to be able to emit your images in `/public/images/`.
+
 ### `useRelativePath`
 
 `useRelativePath` should be `true` if you wish to generate a relative URL to the for each file context.


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
This PR includes a small detail about the `outputPath` option, as I struggled myself the first time, I figured new comers might find it helpful. 