### PR TITLE
feat(index): add a new parameter to `publicPath` (`options.publicPath`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "file-loader",
-  "version": "1.1.4",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default function loader(content) {
 
   validateOptions(schema, options, 'File Loader');
 
-  const context = options.context || this.rootContext || this.options && this.options.context
+  const context = options.context || this.rootContext || (this.options && this.options.context);
 
   let url = loaderUtils.interpolateName(this, options.name, {
     context,

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default function loader(content) {
   if (options.publicPath !== undefined) {
     // support functions as publicPath to generate them dynamically
     publicPath = JSON.stringify(
-      typeof options.publicPath === 'function' ? options.publicPath(url) : options.publicPath + url,
+      typeof options.publicPath === 'function' ? options.publicPath(url, this._module.issuer.resource) : options.publicPath + url,
     );
   }
 

--- a/test/options/__snapshots__/publicPath.test.js.snap
+++ b/test/options/__snapshots__/publicPath.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Options publicPath {Function with ressource param} 1`] = `"module.exports = \\"test/9c87cbf3ba33126ffd25ae7f2f6bbafb.png\\";"`;
+
 exports[`Options publicPath {Function} 1`] = `"module.exports = \\"test/9c87cbf3ba33126ffd25ae7f2f6bbafb.png\\";"`;
 
 exports[`Options publicPath {String} 1`] = `"module.exports = \\"/test/9c87cbf3ba33126ffd25ae7f2f6bbafb.png\\";"`;

--- a/test/options/publicPath.test.js
+++ b/test/options/publicPath.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable
   prefer-destructuring,
 */
+import path from 'path';
 import webpack from '../helpers/compiler';
 
 describe('Options', () => {
@@ -28,6 +29,24 @@ describe('Options', () => {
           options: {
             publicPath(url) {
               return `test/${url}`;
+            },
+          },
+        },
+      };
+
+      const stats = await webpack('fixture.js', config);
+      const { source } = stats.toJson().modules[1];
+
+      expect(source).toMatchSnapshot();
+    });
+
+    test('{Function with ressource param}', async () => {
+      const config = {
+        loader: {
+          test: /(png|jpg|svg)/,
+          options: {
+            publicPath(url, ressource) {
+              return ressource === path.resolve(__dirname, '../fixtures/fixture.js') ? `test/${url}` : `test/${url}`;
             },
           },
         },


### PR DESCRIPTION
This change makes the publicPath function to return the original path of the resource making possible to build custom or relatives paths.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
