### PR TITLE
fix(index): use `path.posix` for platform consistency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export default function loader(content) {
     if (typeof options.outputPath === 'function') {
       outputPath = options.outputPath(url);
     } else {
-      outputPath = path.join(options.outputPath, url);
+      outputPath = path.posix.join(options.outputPath, url);
     }
   }
 
@@ -44,9 +44,9 @@ export default function loader(content) {
     const relativePath = relativeUrl && `${path.dirname(relativeUrl)}/`;
     // eslint-disable-next-line no-bitwise
     if (~relativePath.indexOf('../')) {
-      outputPath = path.join(outputPath, relativePath, url);
+      outputPath = path.posix.join(outputPath, relativePath, url);
     } else {
-      outputPath = path.join(relativePath, url);
+      outputPath = path.posix.join(relativePath, url);
     }
   }
 


### PR DESCRIPTION
### `Issues`

- Fixes #251 

### `Notable Changes`

Use `path.posix` instead of `path` to avoid platform specifics of the `path` module to keep paths consistent

### `Dependants`

- #253  (Ideally lands before this PR)