### PR TITLE
feat: add 'stringifyPublicPath' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module.exports = {
         use: [
           {
             loader: 'file-loader',
-            options: {}  
+            options: {}
           }
         ]
       }
@@ -61,6 +61,7 @@ Emits `file.png` as file in the output directory and returns the public URL
 |**`regExp`**|`{RegExp}`|`'undefined'`|Let you extract some parts of the file path to reuse them in the `name` property|
 |**`context`**|`{String}`|`this.options.context`|Configure a custom file context, defaults to `webpack.config.js` [context](https://webpack.js.org/configuration/entry-context/#context)|
 |**`publicPath`**|`{String\|Function}`|[`__webpack_public_path__ `](https://webpack.js.org/api/module-variables/#__webpack_public_path__-webpack-specific-)|Configure a custom `public` path for your file|
+|**`stringifyPublicPath`**|`{Boolean}`|`true`|By default, the `publicPath` is ran through JSON.stringify. Set this to false if your publicPath requires dynamic properties at runtime|
 |**`outputPath`**|`{String\|Function}`|`'undefined'`|Configure a custom `output` path for your file|
 |**`useRelativePath`**|`{Boolean}`|`false`|Should be `true` if you wish to generate a `context` relative URL for each file|
 |**`emitFile`**|`{Boolean}`|`true`|By default a file is emitted, however this can be disabled if required (e.g. for server side packages)|
@@ -77,7 +78,7 @@ You can configure a custom filename template for your file using the query param
   loader: 'file-loader',
   options: {
     name: '[path][name].[ext]'
-  }  
+  }
 }
 ```
 
@@ -95,7 +96,7 @@ You can configure a custom filename template for your file using the query param
 
       return '[hash].[ext]'
     }
-  }  
+  }
 }
 ```
 
@@ -114,7 +115,7 @@ import img from './customer01/file.png'
   options: {
     regExp: /\/([a-z0-9]+)\/[a-z0-9]+\.png$/,
     name: '[1]-[name].[ext]'
-  }  
+  }
 }
 ```
 
@@ -153,11 +154,11 @@ By default, the path and name you specify will output the file in that same dire
   options: {
     name: '[path][name].[ext]',
     context: ''
-  }  
+  }
 }
 ```
 
-You can specify custom `output` and `public` paths by using `outputPath`, `publicPath` and `useRelativePath`
+You can specify custom `output` and `public` paths by using `outputPath`, `publicPath`, `useRelativePath`, and `stringifyPublicPath`
 
 ### `publicPath`
 
@@ -168,7 +169,7 @@ You can specify custom `output` and `public` paths by using `outputPath`, `publi
   options: {
     name: '[path][name].[ext]',
     publicPath: 'assets/'
-  }  
+  }
 }
 ```
 
@@ -181,7 +182,7 @@ You can specify custom `output` and `public` paths by using `outputPath`, `publi
   options: {
     name: '[path][name].[ext]',
     outputPath: 'images/'
-  }  
+  }
 }
 ```
 
@@ -194,6 +195,33 @@ You can specify custom `output` and `public` paths by using `outputPath`, `publi
   loader: 'file-loader',
   options: {
     useRelativePath: process.env.NODE_ENV === "production"
+  }
+}
+```
+
+### `stringifyPublicPath`
+
+By default the `publicPath` is ran through `JSON.stringify`.
+
+```js
+{
+  loader: 'file-loader',
+  options: {
+    name: '[path][name].[ext]',
+    publicPath: 'assets/'
+  }
+}
+```
+
+If you wish to generate a URL at runtime, `stringifyPublicPath` can be set to `false` (e.g. for CDN switching)
+
+```js
+{
+  loader: 'file-loader',
+  options: {
+    name: '[path][name].[ext]',
+    publicPath: url => `(window.CDN_PATH ? window.CDN_PATH + "${url}" : "${url}")`,
+    stringifyPublicPath: false
   }
 }
 ```
@@ -211,7 +239,7 @@ import img from './file.png'
   loader: 'file-loader',
   options: {
     emitFile: false
-  }  
+  }
 }
 ```
 
@@ -234,7 +262,7 @@ import png from 'image.png'
   loader: 'file-loader',
   options: {
     name: 'dirname/[hash].[ext]'
-  }  
+  }
 }
 ```
 
@@ -248,7 +276,7 @@ dirname/0dcbbaa701328ae351f.png
   loader: 'file-loader',
   options: {
     name: '[sha512:hash:base64:7].[ext]'
-  }  
+  }
 }
 ```
 
@@ -266,7 +294,7 @@ import png from 'path/to/file.png'
   loader: 'file-loader',
   options: {
     name: '[path][name].[ext]?[hash]'
-  }  
+  }
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,9 @@ export default function loader(content) {
       publicPath = `${options.publicPath}/${url}`;
     }
 
-    publicPath = JSON.stringify(publicPath);
+    if (options.stringifyPublicPath === undefined || options.stringifyPublicPath) {
+      publicPath = JSON.stringify(publicPath);
+    }
   }
 
   if (options.emitFile === undefined || options.emitFile) {

--- a/src/options.json
+++ b/src/options.json
@@ -7,6 +7,9 @@
       "type": "string"
     },
     "publicPath": {},
+    "stringifyPublicPath": {
+      "type": "boolean"
+    },
     "outputPath": {},
     "useRelativePath": {
       "type": "boolean"

--- a/test/options/__snapshots__/stringifyPublicPath.test.js.snap
+++ b/test/options/__snapshots__/stringifyPublicPath.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Options stringifyPublicPath {Boolean} False 1`] = `
+Object {
+  "assets": Array [
+    "9c87cbf3ba33126ffd25ae7f2f6bbafb.png",
+  ],
+  "source": "module.exports = (window.CDN_PATH ? window.CDN_PATH + \\"9c87cbf3ba33126ffd25ae7f2f6bbafb.png\\" : \\"9c87cbf3ba33126ffd25ae7f2f6bbafb.png\\");",
+}
+`;
+
+exports[`Options stringifyPublicPath {Boolean} True (Default) 1`] = `
+Object {
+  "assets": Array [
+    "9c87cbf3ba33126ffd25ae7f2f6bbafb.png",
+  ],
+  "source": "module.exports = \\"some/path/9c87cbf3ba33126ffd25ae7f2f6bbafb.png\\";",
+}
+`;

--- a/test/options/stringifyPublicPath.test.js
+++ b/test/options/stringifyPublicPath.test.js
@@ -1,0 +1,44 @@
+/* eslint-disable
+  prefer-destructuring,
+*/
+import webpack from '../helpers/compiler';
+
+describe('Options', () => {
+  describe('stringifyPublicPath', () => {
+    describe('{Boolean}', () => {
+      test('True (Default)', async () => {
+        const config = {
+          loader: {
+            test: /(png|jpg|svg)/,
+            options: {
+              publicPath: url => `some/path/${url}`,
+              stringifyPublicPath: true,
+            },
+          },
+        };
+
+        const stats = await webpack('fixture.js', config);
+        const { assets, source } = stats.toJson().modules[1];
+
+        expect({ assets, source }).toMatchSnapshot();
+      });
+
+      test('False', async () => {
+        const config = {
+          loader: {
+            test: /(png|jpg|svg)/,
+            options: {
+              publicPath: url => `(window.CDN_PATH ? window.CDN_PATH + "${url}" : "${url}")`,
+              stringifyPublicPath: false,
+            },
+          },
+        };
+
+        const stats = await webpack('fixture.js', config);
+        const { assets, source } = stats.toJson().modules[1];
+
+        expect({ assets, source }).toMatchSnapshot();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds a new top-level option called `stringifyPublicPath` (set to true by default). By default, this has no discernable difference between the current functionality of file-loader.

When set to false, the value of `publicPath` will not be processed with `JSON.stringify`. This is useful for the cases where the value of `publicPath` is dynamic and driven by runtime variables.

A strong example has been added to the README that outlines the use case for CDN switching at runtime.