### PR TITLE
docs(readme): clarify support for Webpack v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A file loader module for webpack
 
 ## Requirements
 
-This module requires a minimum of Node v6.9.0 and Webpack v4.0.0.
+This module requires a minimum of Node v6.9.0 and works with Webpack v3 and Webpack v4.
 
 ## Getting Started
 


### PR DESCRIPTION
Update README to clarify that file-loader is working with Webpack v3.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Closes #284.

### Breaking Changes

No.