### PR TITLE
refactor: drop support for webpack < 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@
 
 A file loader module for webpack
 
-## Requirements
-
-This module requires a minimum of Node v6.9.0 and works with Webpack v3 and Webpack v4.
-
 ## Getting Started
 
 To begin, you'll need to install `file-loader`:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "webpack": "^4.0.0"
   },
   "dependencies": {
     "loader-utils": "^1.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-/* eslint-disable
-  multiline-ternary,
-*/
 import path from 'path';
 
 import loaderUtils from 'loader-utils';
@@ -9,18 +6,11 @@ import validateOptions from 'schema-utils';
 import schema from './options.json';
 
 export default function loader(content) {
-  if (!this.emitFile) {
-    throw new Error('File Loader\n\nemitFile is required from module system');
-  }
-
   const options = loaderUtils.getOptions(this) || {};
 
   validateOptions(schema, options, 'File Loader');
 
-  const context =
-    options.context ||
-    this.rootContext ||
-    (this.options && this.options.context);
+  const context = options.context || this.rootContext;
 
   const url = loaderUtils.interpolateName(this, options.name, {
     context,


### PR DESCRIPTION
BREAKING CHANGE: drop support for webpack < 4

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Drop support webpack <4

### Breaking Changes

Yes

### Additional Info

No