### PR TITLE
docs(README): replaced Rule.loader with Rule.use in single loader examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,14 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          name: '[path][name].[ext]',
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[path][name].[ext]',
+            },
+          },
+        ],
       },
     ],
   },
@@ -101,16 +105,20 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          name(file) {
-            if (process.env.NODE_ENV === 'development') {
-              return '[path][name].[ext]';
-            }
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name(file) {
+                if (process.env.NODE_ENV === 'development') {
+                  return '[path][name].[ext]';
+                }
 
-            return '[hash].[ext]';
+                return '[hash].[ext]';
+              },
+            },
           },
-        },
+        ],
       },
     ],
   },
@@ -136,10 +144,14 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          outputPath: 'images',
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              outputPath: 'images',
+            },
+          },
+        ],
       },
     ],
   },
@@ -156,26 +168,30 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          outputPath: (url, resourcePath, context) => {
-            // `resourcePath` is original absolute path to asset
-            // `context` is directory where stored asset (`rootContext`) or `context` option
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              outputPath: (url, resourcePath, context) => {
+                // `resourcePath` is original absolute path to asset
+                // `context` is directory where stored asset (`rootContext`) or `context` option
 
-            // To get relative path you can use
-            // const relativePath = path.relative(context, resourcePath);
+                // To get relative path you can use
+                // const relativePath = path.relative(context, resourcePath);
 
-            if (/my-custom-image\.png/.test(resourcePath)) {
-              return `other_output_path/${url}`;
-            }
+                if (/my-custom-image\.png/.test(resourcePath)) {
+                  return `other_output_path/${url}`;
+                }
 
-            if (/images/.test(context)) {
-              return `image_output_path/${url}`;
-            }
+                if (/images/.test(context)) {
+                  return `image_output_path/${url}`;
+                }
 
-            return `output_path/${url}`;
+                return `output_path/${url}`;
+              },
+            },
           },
-        },
+        ],
       },
     ],
   },
@@ -199,10 +215,14 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          publicPath: 'assets',
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              publicPath: 'assets',
+            },
+          },
+        ],
       },
     ],
   },
@@ -219,26 +239,30 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          publicPath: (url, resourcePath, context) => {
-            // `resourcePath` is original absolute path to asset
-            // `context` is directory where stored asset (`rootContext`) or `context` option
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              publicPath: (url, resourcePath, context) => {
+                // `resourcePath` is original absolute path to asset
+                // `context` is directory where stored asset (`rootContext`) or `context` option
 
-            // To get relative path you can use
-            // const relativePath = path.relative(context, resourcePath);
+                // To get relative path you can use
+                // const relativePath = path.relative(context, resourcePath);
 
-            if (/my-custom-image\.png/.test(resourcePath)) {
-              return `other_public_path/${url}`;
-            }
+                if (/my-custom-image\.png/.test(resourcePath)) {
+                  return `other_public_path/${url}`;
+                }
 
-            if (/images/.test(context)) {
-              return `image_output_path/${url}`;
-            }
+                if (/images/.test(context)) {
+                  return `image_output_path/${url}`;
+                }
 
-            return `public_path/${url}`;
+                return `public_path/${url}`;
+              },
+            },
           },
-        },
+        ],
       },
     ],
   },
@@ -258,10 +282,14 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          context: 'project',
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              context: 'project',
+            },
+          },
+        ],
       },
     ],
   },
@@ -292,10 +320,14 @@ module.exports = {
     rules: [
       {
         test: /\.css$/,
-        loader: 'file-loader',
-        options: {
-          emitFile: false,
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              emitFile: false,
+            },
+          },
+        ],
       },
     ],
   },
@@ -325,11 +357,15 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          regExp: /\/([a-z0-9]+)\/[a-z0-9]+\.png$/,
-          name: '[1]-[name].[ext]',
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              regExp: /\/([a-z0-9]+)\/[a-z0-9]+\.png$/,
+              name: '[1]-[name].[ext]',
+            },
+          },
+        ],
       },
     ],
   },
@@ -446,10 +482,14 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          name: 'dirname/[hash].[ext]',
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: 'dirname/[hash].[ext]',
+            },
+          }
+        ],
       },
     ],
   },
@@ -479,10 +519,14 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          name: '[sha512:hash:base64:7].[ext]',
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[sha512:hash:base64:7].[ext]',
+            },
+          },
+        ],
       },
     ],
   },
@@ -512,10 +556,14 @@ module.exports = {
     rules: [
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          name: '[path][name].[ext]?[hash]',
-        },
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[path][name].[ext]?[hash]',
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Ref: issue #314 

This PR aims to update the doc to reflect use of `Rule.loader` and `Rule.use` in the case of using single (rather than multiple) loaders. This being said, Webpack official docs only deprecated the use of `Rule.loaders` rather than `Rule.loader`. In particular, it pointed out that `Rule.loader` can be used as a shortcut to `Rule.use: [ { loader } ]` (as seen in the following screenshot):
![screen shot 2018-12-27 at 10 08 43 pm](https://user-images.githubusercontent.com/25688258/50478753-0b3c1500-0a27-11e9-8c34-59cc958777ff.png)

However most loaders have updated their docs to consistently use `Rule.use` rather than `Rule.loader` even in the case of using a single loader:
[https://webpack.js.org/loaders/babel-loader/](https://webpack.js.org/loaders/url-loader/)
[https://webpack.js.org/loaders/babel-loader/](https://webpack.js.org/loaders/url-loader/)

### Breaking Changes

No breaking changes

### Additional Info

N/A
fixes #314