### PR TITLE
Exposing output path to subsequent loaders

### DIFF
--- a/src/cjs.js
+++ b/src/cjs.js
@@ -2,3 +2,6 @@ const loader = require('./index');
 
 module.exports = loader.default;
 module.exports.raw = loader.raw;
+module.exports.pitch = function() {
+  loader.getOutputPath(this);
+};

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -2,6 +2,4 @@ const loader = require('./index');
 
 module.exports = loader.default;
 module.exports.raw = loader.raw;
-module.exports.pitch = function() {
-  loader.getOutputPath(this);
-};
+module.exports.pitch = loader.pitch;

--- a/src/index.js
+++ b/src/index.js
@@ -5,19 +5,23 @@ import validateOptions from 'schema-utils';
 
 import schema from './options.json';
 
-export default function loader(content) {
+function getOptions() {
   const options = loaderUtils.getOptions(this) || {};
 
   validateOptions(schema, options, 'File Loader');
 
-  const context = options.context || this.rootContext;
+  return options;
+}
 
-  const url = loaderUtils.interpolateName(this, options.name, {
+function createUrl(context, options, content) {
+  return loaderUtils.interpolateName(this, options.name, {
     context,
     content,
     regExp: options.regExp,
   });
+}
 
+function createOutputPath(url, options, context) {
   let outputPath = url;
 
   if (options.outputPath) {
@@ -28,6 +32,15 @@ export default function loader(content) {
     }
   }
 
+  return outputPath;
+}
+
+export default function loader(content) {
+  const options = getOptions.call(this);
+  const context = options.context || this.rootContext;
+  const url = createUrl.call(this, context, options, content);
+
+  const outputPath = createOutputPath.call(this, url, options, context);
   let publicPath = `__webpack_public_path__ + ${JSON.stringify(outputPath)}`;
 
   if (options.publicPath) {
@@ -53,3 +66,11 @@ export default function loader(content) {
 }
 
 export const raw = true;
+
+export function getOutputPath(loaderInstance) {
+  const options = getOptions.call(loaderInstance);
+  const context = options.context || loaderInstance.rootContext;
+  const url = createUrl.call(loaderInstance, context, options, null);
+
+  return createOutputPath.call(loaderInstance, url, options);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -67,10 +67,19 @@ export default function loader(content) {
 
 export const raw = true;
 
-export function getOutputPath(loaderInstance) {
-  const options = getOptions.call(loaderInstance);
-  const context = options.context || loaderInstance.rootContext;
-  const url = createUrl.call(loaderInstance, context, options, null);
+export function pitch() {
+  const options = getOptions.call(this);
+  const context = options.context || this.rootContext;
+  const url = createUrl.call(this, context, options, null);
 
-  return createOutputPath.call(loaderInstance, url, options);
+  const outputPath = createOutputPath.call(this, url, options, context);
+
+  for (let i = this.loaderIndex; i < this.loaders.length; i++) {
+    const loadr = this.loaders[i];
+    const data = loadr.data || {};
+
+    data.outputPath = outputPath;
+
+    loadr.data = data;
+  }
 }

--- a/test/helpers/compiler.js
+++ b/test/helpers/compiler.js
@@ -28,11 +28,13 @@ const module = (config) => {
 
 const plugins = (config) => [].concat(config.plugins || []);
 
+const outputFolder = 'outputs/';
+
 const output = (config) => {
   return {
     path: path.resolve(
       __dirname,
-      `../outputs/${config.output ? config.output : ''}`
+      `../${outputFolder}${config.output ? config.output : ''}`
     ),
     filename: '[name].bundle.js',
   };
@@ -58,12 +60,16 @@ export default function(fixture, config, options) {
   if (options.output) del.sync(config.output.path);
 
   const compiler = webpack(config);
+  const mfs = new MemoryFS();
 
-  if (!options.output) compiler.outputFileSystem = new MemoryFS();
+  if (!options.output) compiler.outputFileSystem = mfs;
 
   return new Promise((resolve, reject) =>
     compiler.run((err, stats) => {
       if (err) reject(err);
+
+      stats.usedFileSystem = mfs;
+      stats.outputFolder = outputFolder;
 
       resolve(stats);
     })

--- a/test/helpers/pitch-outputPath-loader.js
+++ b/test/helpers/pitch-outputPath-loader.js
@@ -1,0 +1,3 @@
+module.exports = function loader() {
+  return this.data.outputPath;
+};

--- a/test/pitch-outputPath.test.js
+++ b/test/pitch-outputPath.test.js
@@ -1,0 +1,66 @@
+import path from 'path';
+
+import webpack from './helpers/compiler';
+
+describe('pitch output path', () => {
+  it('value should be the same as the eventual location its written to', async () => {
+    const config = {
+      rules: [
+        {
+          test: /\.(js)$/i,
+          use: [
+            {
+              loader: path.resolve(__dirname, '../src/cjs'),
+            },
+            {
+              loader: path.resolve(
+                __dirname,
+                './helpers/pitch-outputPath-loader'
+              ),
+            },
+          ],
+        },
+      ],
+    };
+
+    const stats = await webpack('fixture.js', config);
+    const [module] = stats.toJson().modules;
+    const { assets } = module;
+    const filePath = path.resolve(__dirname, stats.outputFolder, assets[0]);
+    const content = stats.usedFileSystem.readFileSync(filePath).toString();
+
+    expect(content).toEqual('[hash].js');
+  });
+
+  it('should handle [path][name].[ext] correctly when using nested folders', async () => {
+    const config = {
+      rules: [
+        {
+          test: /\.(js)$/i,
+          use: [
+            {
+              loader: path.resolve(__dirname, '../src/cjs'),
+              options: {
+                name: '[path][name].[ext]',
+              },
+            },
+            {
+              loader: path.resolve(
+                __dirname,
+                './helpers/pitch-outputPath-loader'
+              ),
+            },
+          ],
+        },
+      ],
+    };
+
+    const stats = await webpack('nested/fixture.js', config);
+    const [module] = stats.toJson().modules;
+    const { assets } = module;
+    const filePath = path.resolve(__dirname, stats.outputFolder, assets[0]);
+    const content = stats.usedFileSystem.readFileSync(filePath).toString();
+
+    expect(content).toEqual('nested/fixture.js');
+  });
+});


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

In certain projects you want to parse a lot of files which have their own dependencies. When using file-loader you can tell it into which folder the files need to be written. The problem is the loader processing the files, doesn't know to which paths all the files are written and thus cannot make a correct relative path dependency on those files. By pitching the calculated output path of file-loader to all subsequent loaders they then can use this information to correctly resolve a relative path.

In my case I have multiple .html files which include some .less files specific to it. These files need to be placed in the same folder. I don't want to worry inside the .html file about the setup of webpack so I just want to include the .less file relatively. For this to work correctly extract-loader should know where the .html file needs to be written to create correct relative paths for the .less files.

I've already setup a version of  [extract-loader](https://github.com/NetMatch/extract-loader) which uses these changes to resolve paths relatively.

### Breaking Changes

No breaking changes.

### Additional Info

There can be parts of the path which can't be correctly resolved yet like the `[hash]` as it relies on the content of the file for the hash to be formed. The output path for this file will just keep `[hash]` as part of the output path name. As it's unique to this file it will still resolve relative paths correctly.