### PR TITLE
Allow publicPath handler to return a function instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,12 @@ module.exports = {
                 if (/images/.test(context)) {
                   return `image_output_path/${url}`;
                 }
+                
+                if (/runtime/.test(context)) {
+                  return function(url) {
+                    return window.customPublicPath + url;
+                  }
+                }
 
                 return `public_path/${url}`;
               },

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,10 @@ export default function loader(content) {
       }${url}`;
     }
 
-    publicPath = JSON.stringify(publicPath);
+    publicPath =
+      typeof publicPath === 'function'
+        ? `(${publicPath})("${url}")`
+        : JSON.stringify(publicPath);
   }
 
   if (typeof options.emitFile === 'undefined' || options.emitFile) {

--- a/test/__snapshots__/publicPath-option.test.js.snap
+++ b/test/__snapshots__/publicPath-option.test.js.snap
@@ -27,6 +27,18 @@ Object {
 }
 `;
 
+exports[`when applied with \`publicPath\` option matches snapshot for \`{Function}\` value returning \`{Function}\` 1`] = `
+Object {
+  "assets": Array [
+    "9c87cbf3ba33126ffd25ae7f2f6bbafb.png",
+  ],
+  "source": "module.exports = (function publicPath(url) {
+              // eslint-disable-next-line no-undef
+              return window.imageCdnBasePath + url;
+            })(\\"9c87cbf3ba33126ffd25ae7f2f6bbafb.png\\");",
+}
+`;
+
 exports[`when applied with \`publicPath\` option matches snapshot for \`{String}\` value 1`] = `
 Object {
   "assets": Array [

--- a/test/publicPath-option.test.js
+++ b/test/publicPath-option.test.js
@@ -126,4 +126,26 @@ describe('when applied with `publicPath` option', () => {
 
     expect({ assets, source }).toMatchSnapshot();
   });
+
+  it('matches snapshot for `{Function}` value returning `{Function}`', async () => {
+    const config = {
+      loader: {
+        test: /(png|jpg|svg)/,
+        options: {
+          publicPath() {
+            return function publicPath(url) {
+              // eslint-disable-next-line no-undef
+              return window.imageCdnBasePath + url;
+            };
+          },
+        },
+      },
+    };
+
+    const stats = await webpack('fixture.js', config);
+    const [module] = stats.toJson().modules;
+    const { assets, source } = module;
+
+    expect({ assets, source }).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Sometimes you might need to construct the path to your assets in runtime (for example when using multi CDN for different types of assets). Currently the only way to change the base path is to update `__webpack_public_path__` and it will affect all the assets at once 😞

If only we could have a function instead of plain string which will be executed in runtime and return the path based on the asset type, variables, cookies or whatever you want to figure out the right base path... oh wait, but we can!
This PR is to rescue!  🎉

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

No breaking changes.
Current implementation just produces nothing If you return a function  instead of string out of the `options.publicPath` handler because ```JSON.stringify(function) === undefined```
This PR enhances `file-loader` and now you can return a function which will be executed in runtime so you can enjoy all your variables and helper functions in it and construct a publicPath of your dream.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->