### PR TITLE
compatibility for chrome extension content script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,10 @@ export default function loader(content) {
   const esModule =
     typeof options.esModule !== 'undefined' ? options.esModule : true;
 
+  if (options.useInChromeExtensionContentScript === true) {
+    publicPath = `chrome.runtime.getURL(${publicPath});`;
+  }
+
   return `${esModule ? 'export default' : 'module.exports ='} ${publicPath};`;
 }
 

--- a/src/options.json
+++ b/src/options.json
@@ -60,6 +60,10 @@
     "esModule": {
       "description": "By default, file-loader generates JS modules that use the ES modules syntax.",
       "type": "boolean"
+    },
+    "useInChromeExtensionContentScript": {
+      "description": "Add `chrome.runtime.getURL` call for chrome extension content scripts.",
+      "type": "boolean"
     }
   },
   "type": "object"


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When developing chrome extension, request urls for files will be like `chrome-extension://${extension_id}/file`, not `http`. These urls can be generated by calling `chrome.runtime.getURL`.

### Breaking Changes

1. Add `useInChromeExtensionContentScript` in `options`.
2. When `useInChromeExtensionContentScript === true`, wrap `publicPath` with `chrome.runtime.getURL`.

### Additional Info
